### PR TITLE
Added ByPackageScore ordering strategy to MemoryPool

### DIFF
--- a/miner/src/memory_pool.rs
+++ b/miner/src/memory_pool.rs
@@ -293,7 +293,7 @@ impl Storage {
 		}
 
 		// now modify all ancestor entries
-		if miner_virtual_fee_change != 0i64 {
+		if miner_virtual_fee_change != 0 {
 			ancestors.map(|ancestors| {
 				for ancestor_hash in ancestors {
 					if let Some(ref mut ancestor_entry) = self.by_hash.get_mut(&ancestor_hash) {


### PR DESCRIPTION
This is the main strategy (as I understood from bitcoin sources) to select transactions for the blocks.
Also many other fixes like:
(1) new tests
(2) as a result of new tests => refactoring of internal storage => MemoryPool now supporting complex transactions chains
(3) renamed internal timestamp field as suggested in previous PR (however sorting by this field is still visible to API clients as sorting by timestamp - becauseit works so).

Sorry if it is too big to review - I've started with implementing new ordering strategy, then added some tests => found issues => refactored internal storage => here we are with ~600 LOCs changed.
