### PR TITLE
Initial sync manager version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,9 @@ version = "0.1.0"
 dependencies = [
  "chain 0.1.0",
  "db 0.1.0",
+ "futures 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "message 0.1.0",
  "miner 0.1.0",
@@ -619,6 +622,7 @@ dependencies = [
  "primitives 0.1.0",
  "test-data 0.1.0",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.0 (git+https://github.com/debris/tokio-core)",
  "verification 0.1.0",
 ]
 

--- a/pbtc/commands/start.rs
+++ b/pbtc/commands/start.rs
@@ -27,7 +27,8 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 	let db = open_db(cfg.use_disk_database);
 	init_db(&db);
 
-	let sync_connection_factory = create_sync_connection_factory(db);
+	let sync_handle = el.handle();
+	let sync_connection_factory = create_sync_connection_factory(&sync_handle, db);
 
 	let p2p = p2p::P2P::new(p2p_cfg, sync_connection_factory, el.handle());
 	try!(p2p.run().map_err(|_| "Failed to start p2p module"));

--- a/pbtc/main.rs
+++ b/pbtc/main.rs
@@ -43,5 +43,3 @@ fn run() -> Result<(), String> {
 		_ => commands::start(cfg),
 	}
 }
-
-

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -7,6 +7,10 @@ authors = ["Ethcore <admin@ethcore.io>"]
 parking_lot = "0.3"
 log = "0.3"
 time = "0.1"
+futures = "0.1"
+futures-cpupool = "0.1"
+tokio-core = { git = "https://github.com/debris/tokio-core" }
+linked-hash-map = "0.3"
 
 chain = { path = "../chain" }
 db = { path = "../db" }

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -2,9 +2,13 @@ extern crate chain;
 extern crate db;
 #[macro_use]
 extern crate log;
+extern crate futures;
+extern crate futures_cpupool;
+extern crate tokio_core;
 extern crate message;
 extern crate p2p;
 extern crate parking_lot;
+extern crate linked_hash_map;
 extern crate primitives;
 extern crate test_data;
 extern crate time;
@@ -19,11 +23,13 @@ mod local_node;
 mod synchronization_chain;
 mod synchronization_client;
 mod synchronization_executor;
+mod synchronization_manager;
 mod synchronization_peers;
 mod synchronization_server;
 
 use std::sync::Arc;
 use parking_lot::{Mutex, RwLock};
+use tokio_core::reactor::Handle;
 
 /// Sync errors.
 #[derive(Debug)]
@@ -42,7 +48,7 @@ pub fn create_sync_blocks_writer(db: Arc<db::Store>) -> blocks_writer::BlocksWri
 }
 
 /// Create inbound synchronization connections factory for given `db`.
-pub fn create_sync_connection_factory(db: Arc<db::Store>) -> p2p::LocalSyncNodeRef {
+pub fn create_sync_connection_factory(handle: &Handle, db: Arc<db::Store>) -> p2p::LocalSyncNodeRef {
 	use synchronization_chain::Chain as SyncChain;
 	use synchronization_executor::LocalSynchronizationTaskExecutor as SyncExecutor;
 	use local_node::LocalNode as SyncNode;
@@ -53,7 +59,7 @@ pub fn create_sync_connection_factory(db: Arc<db::Store>) -> p2p::LocalSyncNodeR
 	let sync_chain = Arc::new(RwLock::new(SyncChain::new(db)));
 	let sync_executor = SyncExecutor::new(sync_chain.clone());
 	let sync_server = Arc::new(Mutex::new(SynchronizationServer::new(sync_chain.clone(), sync_executor.clone())));
-	let sync_client = SynchronizationClient::new(SynchronizationConfig::default(), sync_executor.clone(), sync_chain);
+	let sync_client = SynchronizationClient::new(SynchronizationConfig::default(), handle, sync_executor.clone(), sync_chain);
 	let sync_node = Arc::new(SyncNode::new(sync_server, sync_client, sync_executor));
 	SyncConnectionFactory::with_local_node(sync_node)
 }

--- a/sync/src/synchronization_manager.rs
+++ b/sync/src/synchronization_manager.rs
@@ -1,0 +1,26 @@
+use time::precise_time_s;
+use synchronization_peers::Peers;
+
+/// Management interval (in ms)
+pub const MANAGEMENT_INTERVAL_MS: u64 = 10 * 1000;
+/// Response time to decrease peer score
+const FAILURE_INTERVAL_S: f64 = 5f64;
+
+/// Management worker
+pub fn manage_synchronization_peers(peers: &mut Peers) {
+	// reset tasks for peers, which has not responded during given period
+	for (worst_peer_index, worst_peer_time) in peers.worst_peers() {
+		// check if peer has not responded within given time
+		let time_diff = worst_peer_time - precise_time_s();
+		if time_diff <= FAILURE_INTERVAL_S {
+			break;
+		}
+
+		// decrease score && move to the idle queue
+		trace!(target: "sync", "Failed to get response from peer#{} in {} seconds", worst_peer_index, time_diff);
+		peers.reset_tasks(worst_peer_index);
+		if peers.on_peer_failure(worst_peer_index) {
+			trace!(target: "sync", "Too many failures for peer#{}. Excluding from synchronization", worst_peer_index);
+		}
+	}
+}

--- a/sync/src/synchronization_peers.rs
+++ b/sync/src/synchronization_peers.rs
@@ -1,16 +1,23 @@
 use std::collections::{HashMap, HashSet};
 use std::collections::hash_map::Entry;
 use primitives::hash::H256;
+use linked_hash_map::LinkedHashMap;
+use time::precise_time_s;
 
-// TODO: sync score for peers + choose peers based on their score
+/// Max peer failures # before excluding from sync process
+const MAX_PEER_FAILURES: usize = 8;
 
 /// Set of peers selected for synchronization.
 #[derive(Debug)]
 pub struct Peers {
-	/// Peers that have not pending blocks requests.
-	idle_peers: HashSet<usize>,
-	/// Pending block requests by peer.
-	blocks_requests: HashMap<usize, HashSet<H256>>,
+	/// Peers that have no pending requests.
+	idle: HashSet<usize>,
+	/// Pending requests by peer.
+	requests: HashMap<usize, HashSet<H256>>,
+	/// Peers failures.
+	failures: HashMap<usize, usize>,
+	/// Last message time from peer
+	times: LinkedHashMap<usize, f64>,
 }
 
 /// Information on synchronization peers
@@ -26,8 +33,10 @@ pub struct Information {
 impl Peers {
 	pub fn new() -> Peers {
 		Peers {
-			idle_peers: HashSet::new(),
-			blocks_requests: HashMap::new(),
+			idle: HashSet::new(),
+			requests: HashMap::new(),
+			failures: HashMap::new(),
+			times: LinkedHashMap::new(),
 		}
 	}
 
@@ -35,75 +44,122 @@ impl Peers {
 	#[cfg(test)]
 	pub fn information(&self) -> Information {
 		Information {
-			idle: self.idle_peers.len(),
-			active: self.blocks_requests.len(),
+			idle: self.idle.len(),
+			active: self.requests.len(),
 		}
 	}
 
 	/// Get idle peer.
 	#[cfg(test)]
 	pub fn idle_peer(&self) -> Option<usize> {
-		self.idle_peers.iter().cloned().next()
+		self.idle.iter().cloned().next()
 	}
 
 	/// Get idle peers.
 	pub fn idle_peers(&self) -> Vec<usize> {
-		self.idle_peers.iter().cloned().collect()
+		self.idle.iter().cloned().collect()
+	}
+
+	/// Get worst peer.
+	pub fn worst_peers(&self) -> Vec<(usize, f64)> {
+		self.times.iter().map(|(&pi, &t)| (pi, t)).collect()
 	}
 
 	/// Insert new synchronization peer.
 	pub fn insert(&mut self, peer_index: usize) {
-		if !self.idle_peers.contains(&peer_index) && !self.blocks_requests.contains_key(&peer_index) {
-			self.idle_peers.insert(peer_index);
-		}
-	}
-
-	/// Block is received from peer.
-	pub fn on_block_received(&mut self, peer_index: usize, block_hash: &H256) {
-		if let Entry::Occupied(mut entry) = self.blocks_requests.entry(peer_index) {
-			entry.get_mut().remove(block_hash);
-			if entry.get().is_empty() {
-				self.idle_peers.insert(peer_index);
-				entry.remove_entry();
-			}
+		if !self.idle.contains(&peer_index) && !self.requests.contains_key(&peer_index) {
+			self.idle.insert(peer_index);
 		}
 	}
 
 	/// Peer has been disconnected
 	pub fn on_peer_disconnected(&mut self, peer_index: usize) {
-		self.idle_peers.remove(&peer_index);
-		self.blocks_requests.remove(&peer_index);
+		self.idle.remove(&peer_index);
+		self.requests.remove(&peer_index);
+		self.failures.remove(&peer_index);
+		self.times.remove(&peer_index);
+	}
+
+	/// Block is received from peer.
+	pub fn on_block_received(&mut self, peer_index: usize, block_hash: &H256) {
+		if let Entry::Occupied(mut entry) = self.requests.entry(peer_index) {
+			entry.get_mut().remove(block_hash);
+			if entry.get().is_empty() {
+				self.idle.insert(peer_index);
+				entry.remove_entry();
+			}
+		}
+		self.on_peer_message(peer_index);
 	}
 
 	/// Blocks have been requested from peer.
 	pub fn on_blocks_requested(&mut self, peer_index: usize, blocks_hashes: &Vec<H256>) {
 		// inventory can only be requested from idle peers
-		assert!(!self.blocks_requests.contains_key(&peer_index));
+		assert!(!self.requests.contains_key(&peer_index));
 
-		self.idle_peers.remove(&peer_index);
-		self.blocks_requests.entry(peer_index).or_insert(HashSet::new()).extend(blocks_hashes.iter().cloned());
+		self.idle.remove(&peer_index);
+		self.requests.entry(peer_index).or_insert(HashSet::new()).extend(blocks_hashes.iter().cloned());
+		self.times.insert(peer_index, precise_time_s());
 	}
 
 	/// Inventory has been requested from peer.
 	pub fn on_inventory_requested(&mut self, peer_index: usize) {
 		// inventory can only be requested from idle peers
-		assert!(!self.blocks_requests.contains_key(&peer_index));
-		self.idle_peers.remove(&peer_index);
+		assert!(!self.requests.contains_key(&peer_index));
 
+		self.idle.remove(&peer_index);
 		// peer is now out-of-synchronization process, because:
-		// 1) if it has new blocks, it will respond with `inventory` message && will be insrted back here
+		// 1) if it has new blocks, it will respond with `inventory` message && will be inserted back here
 		// 2) if it has no new blocks => either synchronization is completed, or it is behind us in sync
+	}
+
+	/// We have failed to get response from peer during given period
+	pub fn on_peer_failure(&mut self, peer_index: usize) -> bool {
+		let peer_failures = match self.failures.entry(peer_index) {
+			Entry::Occupied(mut entry) => {
+				let failures = entry.get() + 1;
+				entry.insert(failures) + 1;
+				failures
+			},
+			Entry::Vacant(entry) => *entry.insert(1),
+		};
+
+		let too_much_failures = peer_failures >= MAX_PEER_FAILURES;
+		if too_much_failures {
+			self.failures.remove(&peer_index);
+			self.requests.remove(&peer_index);
+			self.times.remove(&peer_index);
+		}
+		too_much_failures
 	}
 
 	/// Reset peers state
 	pub fn reset(&mut self) {
-		self.idle_peers.extend(self.blocks_requests.drain().map(|(k, _)| k));
+		self.idle.extend(self.requests.drain().map(|(k, _)| k));
+		self.failures.clear();
+		self.times.clear();
+	}
+
+	/// Reset peer tasks
+	pub fn reset_tasks(&mut self, peer_index: usize) {
+		self.requests.remove(&peer_index);
+		self.times.remove(&peer_index);
+		self.idle.insert(peer_index);
+	}
+
+	/// When sync message is received from peer
+	fn on_peer_message(&mut self, peer_index: usize) {
+		self.failures.remove(&peer_index);
+		self.times.remove(&peer_index);
+		if self.requests.contains_key(&peer_index) {
+			self.times.insert(peer_index, precise_time_s());
+		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use super::Peers;
+	use super::{Peers, MAX_PEER_FAILURES};
 	use primitives::hash::H256;
 
 	#[test]
@@ -199,6 +255,43 @@ mod tests {
 
 		peers.on_block_received(8, &H256::default());
 		assert_eq!(peers.information().idle, 3);
+		assert_eq!(peers.information().active, 0);
+	}
+
+	#[test]
+	fn peers_worst() {
+		let mut peers = Peers::new();
+
+		peers.insert(1);
+		peers.insert(2);
+		assert_eq!(peers.worst_peers(), vec![]);
+
+		peers.on_blocks_requested(1, &vec![H256::default()]);
+		assert_eq!(peers.worst_peers().len(), 1);
+		assert_eq!(peers.worst_peers()[0].0, 1);
+
+		peers.on_blocks_requested(2, &vec![H256::default()]);
+		assert_eq!(peers.worst_peers().len(), 2);
+		assert_eq!(peers.worst_peers()[0].0, 1);
+		assert_eq!(peers.worst_peers()[1].0, 2);
+
+		assert_eq!(peers.information().idle, 0);
+		assert_eq!(peers.information().active, 2);
+
+		peers.reset_tasks(1);
+
+		assert_eq!(peers.information().idle, 1);
+		assert_eq!(peers.information().active, 1);
+
+		assert_eq!(peers.worst_peers().len(), 1);
+		assert_eq!(peers.worst_peers()[0].0, 2);
+
+		for _ in 0..MAX_PEER_FAILURES {
+			peers.on_peer_failure(2);
+		}
+
+		assert_eq!(peers.worst_peers().len(), 0);
+		assert_eq!(peers.information().idle, 1);
 		assert_eq!(peers.information().active, 0);
 	}
 }


### PR DESCRIPTION
Management worker will help in situations when we have sent blocks request to some peer & it doesn't respond within some time. Peer will be penalized then & request will be redirected to other idle peers (if there are any) or resent to the same peer. If there are too many failures for the peer during single sync session, it will be ignored in this session.
Later the same CpuPool will be used by @NikVolf for verification futures.