### PR TITLE
regression tests support

### DIFF
--- a/message/src/common/magic.rs
+++ b/message/src/common/magic.rs
@@ -6,6 +6,7 @@ use Error;
 
 const MAGIC_MAINNET: u32 = 0xD9B4BEF9;
 const MAGIC_TESTNET: u32 = 0x0709110B;
+const MAGIC_REGTEST: u32 = 0xDAB5BFFA;
 
 /// Bitcoin network
 /// https://bitcoin.org/en/glossary/mainnet
@@ -14,6 +15,7 @@ pub enum Magic {
 	/// The original and main network for Bitcoin transactions, where satoshis have real economic value.
 	Mainnet,
 	Testnet,
+	Regtest,
 }
 
 impl From<Magic> for u32 {
@@ -21,6 +23,7 @@ impl From<Magic> for u32 {
 		match m {
 			Magic::Mainnet => MAGIC_MAINNET,
 			Magic::Testnet => MAGIC_TESTNET,
+			Magic::Regtest => MAGIC_REGTEST,
 		}
 	}
 }
@@ -30,6 +33,7 @@ impl Magic {
 		match magic {
 			MAGIC_MAINNET => Ok(Magic::Mainnet),
 			MAGIC_TESTNET => Ok(Magic::Testnet),
+			MAGIC_REGTEST => Ok(Magic::Regtest),
 			_ => Err(Error::InvalidMagic),
 		}
 	}
@@ -38,6 +42,7 @@ impl Magic {
 		match *self {
 			Magic::Mainnet => 8333,
 			Magic::Testnet => 18333,
+			Magic::Regtest => 18444,
 		}
 	}
 
@@ -45,6 +50,7 @@ impl Magic {
 		match *self {
 			Magic::Mainnet => 8332,
 			Magic::Testnet => 18332,
+			Magic::Regtest => 18443,
 		}
 	}
 }
@@ -58,14 +64,16 @@ impl Serializable for Magic {
 #[cfg(test)]
 mod tests {
 	use Error;
-	use super::{Magic, MAGIC_MAINNET, MAGIC_TESTNET};
+	use super::{Magic, MAGIC_MAINNET, MAGIC_TESTNET, MAGIC_REGTEST};
 
 	#[test]
 	fn test_network_magic_number() {
 		assert_eq!(MAGIC_MAINNET, Magic::Mainnet.into());
 		assert_eq!(MAGIC_TESTNET, Magic::Testnet.into());
+		assert_eq!(MAGIC_REGTEST, Magic::Regtest.into());
 		assert_eq!(Magic::from_u32(MAGIC_MAINNET).unwrap(), Magic::Mainnet);
 		assert_eq!(Magic::from_u32(MAGIC_TESTNET).unwrap(), Magic::Testnet);
+		assert_eq!(Magic::from_u32(MAGIC_REGTEST).unwrap(), Magic::Regtest);
 		assert_eq!(Magic::from_u32(0).unwrap_err(), Error::InvalidMagic);
 	}
 
@@ -73,11 +81,13 @@ mod tests {
 	fn test_network_port() {
 		assert_eq!(Magic::Mainnet.port(), 8333);
 		assert_eq!(Magic::Testnet.port(), 18333);
+		assert_eq!(Magic::Regtest.port(), 18444);
 	}
 
 	#[test]
 	fn test_network_rpc_port() {
 		assert_eq!(Magic::Mainnet.rpc_port(), 8332);
 		assert_eq!(Magic::Testnet.rpc_port(), 18332);
+		assert_eq!(Magic::Regtest.rpc_port(), 18443);
 	}
 }

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 
 pub use primitives::{hash, bytes};
 
-pub use common::{Command, Magic};
+pub use common::{Command, Magic, Services};
 pub use message::{Message, MessageHeader, Payload, to_raw_message};
 pub use serialization::{serialize_payload, deserialize_payload};
 pub use error::{Error, MessageResult};

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -25,7 +25,7 @@ mod config;
 mod event_loop;
 mod p2p;
 
-pub const VERSION: u32 = 70_001;
+pub const VERSION: u32 = 70_014;
 pub const USER_AGENT: &'static str = "pbtc";
 
 pub use primitives::{hash, bytes};

--- a/p2p/src/p2p.rs
+++ b/p2p/src/p2p.rs
@@ -194,8 +194,9 @@ impl Context {
 					channel.session().initialize(channel.clone());
 					Context::on_message(context.clone(), channel)
 				},
-				Ok(DeadlineStatus::Meet(Err(_))) => {
+				Ok(DeadlineStatus::Meet(Err(err))) => {
 					// protocol error
+					trace!("Accepting handshake from {} failed with error: {}", socket, err);
 					// TODO: close socket
 					context.node_table.write().note_failure(&socket);
 					context.connection_counter.note_close_inbound_connection();
@@ -203,7 +204,7 @@ impl Context {
 				},
 				Ok(DeadlineStatus::Timeout) => {
 					// connection time out
-					trace!("Handshake with {} timedout", socket);
+					trace!("Accepting handshake from {} timed out", socket);
 					// TODO: close socket
 					context.node_table.write().note_failure(&socket);
 					context.connection_counter.note_close_inbound_connection();
@@ -211,6 +212,7 @@ impl Context {
 				},
 				Err(_) => {
 					// network error
+					trace!("Accepting handshake from {} failed with network error", socket);
 					context.node_table.write().note_failure(&socket);
 					context.connection_counter.note_close_inbound_connection();
 					finished(Ok(())).boxed()

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -5,7 +5,10 @@ about: Parity bitcoin client
 args:
     - testnet:
         long: testnet
-        help: Use the test chain
+        help: Use the test network
+    - regtest:
+        long: regtest
+        help: Use private network for regtest
     - connect:
         short: c
         long: connect

--- a/pbtc/commands/start.rs
+++ b/pbtc/commands/start.rs
@@ -1,5 +1,6 @@
 use std::net::SocketAddr;
 use sync::create_sync_connection_factory;
+use message::Services;
 use util::{open_db, init_db, node_table_path};
 use {config, p2p};
 
@@ -15,7 +16,7 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 		connection: p2p::NetConfig {
 			magic: cfg.magic,
 			local_address: SocketAddr::new("127.0.0.1".parse().unwrap(), cfg.port),
-			services: Default::default(),
+			services: Services::default().with_network(true),
 			user_agent: "pbtc".into(),
 			start_height: 0,
 			relay: false,

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -14,9 +14,11 @@ pub struct Config {
 pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 	let print_to_console = matches.is_present("printtoconsole");
 	let use_disk_database = matches.is_present("diskdb");
-	let magic = match matches.is_present("testnet") {
-		true => Magic::Testnet,
-		false => Magic::Mainnet,
+	let magic = match (matches.is_present("testnet"), matches.is_present("regtest")) {
+		(true, false) => Magic::Testnet,
+		(false, true) => Magic::Regtest,
+		(false, false) => Magic::Mainnet,
+		(true, true) => return Err("Only one testnet option can be used".into()),
 	};
 
 	let port = match matches.value_of("port") {


### PR DESCRIPTION
Support for running regression tests from https://github.com/TheBlueMatt/test-scripts

It's not described in the readme, so I will briefly explain how to run these tests agains `bitcoind` and `pbtc`.

1. Start either `bitcoind` or `pbtc`
  - `bitcoind` needs to be started with `-regtest` option. This option is not visible in cli's help. I found the description [here](https://bitcoin.org/en/developer-examples#regtest-mode)

    ```
    ./bitcoind -printtoconsole -regtest
    ```

  - `pbtc`. There is new cli option `--regtest`
    ```
    ./target/release/pbtc --regtest
    ```

2. Start tests

    ```
    cd test-scripts
    java -jar pull-tests-f56eec3.jar
    ```

Currently all tests fail. I've also noticed that `bitcoind` sends slightly different messages when syncing than we do. We should definitely look more closely into it. I'm not adding wireshark logs, cause it's super easy to grab them from loopback with `bitcoin` filter.