### PR TITLE
Proper failed reorgs propagation

### DIFF
--- a/db/src/storage.rs
+++ b/db/src/storage.rs
@@ -645,7 +645,7 @@ impl Store for Storage {
 							return Err(Error::reorganize(&hash));
 						},
 						ConsistencyError::UnknownSpending(hash) => {
-							warn!(target: "reorg", "Failed to reorganize to {} due to double-spend at {}", &block_hash, &hash);
+							warn!(target: "reorg", "Failed to reorganize to {} due to spending unknown transaction {}", &block_hash, &hash);
 							// return without any commit
 							return Err(Error::reorganize(&hash));
 						},


### PR DESCRIPTION
after #126 
due to this it is now temporary failing on b8, by @svyatonik  changes to sync should resolve this

```
thread 'Sync verification thread' panicked at 'Error inserting to db.: Consistency(Reorganize(56dc87ca9a3ef28077f87e3a9be9dc8c3a8880782f8553d8d78009728213bb64))', ../src/libcore/result.rs:788
```