### PR TITLE
Removed --diskdb option

### DIFF
--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -29,9 +29,6 @@ args:
     - printtoconsole:
         long: printtoconsole
         help: Send trace/debug info to console instead of debug.log file
-    - diskdb:
-        long: diskdb
-        help: Use disk storage instead of in-memory one
 subcommands:
     - import:
         about: Import blocks from bitcoin core database

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -8,12 +8,10 @@ pub struct Config {
 	pub connect: Option<net::SocketAddr>,
 	pub seednode: Option<String>,
 	pub print_to_console: bool,
-	pub use_disk_database: bool,
 }
 
 pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 	let print_to_console = matches.is_present("printtoconsole");
-	let use_disk_database = matches.is_present("diskdb");
 	let magic = match (matches.is_present("testnet"), matches.is_present("regtest")) {
 		(true, false) => Magic::Testnet,
 		(false, true) => Magic::Regtest,
@@ -47,7 +45,6 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		port: port,
 		connect: connect,
 		seednode: seednode,
-		use_disk_database: use_disk_database,
 	};
 
 	Ok(config)

--- a/pbtc/util.rs
+++ b/pbtc/util.rs
@@ -5,13 +5,9 @@ use chain::RepresentH256;
 use {db, APP_INFO};
 use config::Config;
 
-pub fn open_db(cfg: &Config) -> Arc<db::Store> {
-	if cfg.use_disk_database {
-		let db_path = app_dir(AppDataType::UserData, &APP_INFO, "db").expect("Failed to get app dir");
-		Arc::new(db::Storage::new(db_path).expect("Failed to open database"))
-	} else {
-		Arc::new(db::TestStorage::default())
-	}
+pub fn open_db(_cfg: &Config) -> Arc<db::Store> {
+	let db_path = app_dir(AppDataType::UserData, &APP_INFO, "db").expect("Failed to get app dir");
+	Arc::new(db::Storage::new(db_path).expect("Failed to open database"))
 }
 
 pub fn node_table_path() -> PathBuf {


### PR DESCRIPTION
TestStorage is now far behind the disk storage (no forks support, no verification support) + much slower => currently it is unuseful at all.