### PR TITLE
Support BIP16

### DIFF
--- a/message/src/common/consensus.rs
+++ b/message/src/common/consensus.rs
@@ -3,6 +3,9 @@ use super::Magic;
 #[derive(Debug, Clone)]
 /// Parameters that influence chain consensus.
 pub struct ConsensusParams {
+	/// Time when BIP16 becomes active.
+	/// See https://github.com/bitcoin/bips/blob/master/bip-0016.mediawiki
+	pub bip16_time: u32,
 	/// Block height at which BIP65 becomes active.
 	/// See https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
 	pub bip65_height: u32,
@@ -12,12 +15,15 @@ impl ConsensusParams {
 	pub fn with_magic(magic: Magic) -> Self {
 		match magic {
 			Magic::Mainnet => ConsensusParams {
-				bip65_height: 388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
+				bip16_time: 1333238400,	// Apr 1 2012
+				bip65_height: 388381,	// 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
 			},
 			Magic::Testnet => ConsensusParams {
-				bip65_height: 581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
+				bip16_time: 1333238400,	// Apr 1 2012
+				bip65_height: 581885,	// 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
 			},
 			Magic::Regtest => ConsensusParams {
+				bip16_time: 1333238400,	// Apr 1 2012
 				bip65_height: 1351,
 			},
 		}

--- a/verification/src/chain_verifier.rs
+++ b/verification/src/chain_verifier.rs
@@ -14,6 +14,7 @@ const MAX_BLOCK_SIZE: usize = 1000000;
 
 pub struct ChainVerifier {
 	store: Arc<db::Store>,
+	verify_p2sh: bool,
 	verify_clocktimeverify: bool,
 	skip_pow: bool,
 	skip_sig: bool,
@@ -23,6 +24,7 @@ impl ChainVerifier {
 	pub fn new(store: Arc<db::Store>) -> Self {
 		ChainVerifier {
 			store: store,
+			verify_p2sh: false,
 			verify_clocktimeverify: false,
 			skip_pow: false,
 			skip_sig: false
@@ -38,6 +40,11 @@ impl ChainVerifier {
 	#[cfg(test)]
 	pub fn signatures_skip(mut self) -> Self {
 		self.skip_sig = true;
+		self
+	}
+
+	pub fn verify_p2sh(mut self, verify: bool) -> Self {
+		self.verify_p2sh = verify;
 		self
 	}
 
@@ -141,7 +148,7 @@ impl ChainVerifier {
 			let output: Script = paired_output.script_pubkey.to_vec().into();
 
 			let flags = VerificationFlags::default()
-				.verify_p2sh(true)
+				.verify_p2sh(self.verify_p2sh)
 				.verify_clocktimeverify(self.verify_clocktimeverify);
 
 			// for tests only, skips as late as possible


### PR DESCRIPTION
As in bitcoind:
https://github.com/bitcoin/bitcoin/blob/master/src/main.cpp#L2428

We could use block number, as for BIP65, but in reference client time is used to separate pre-BIP16 blocks from post-BIP16. I've implemented the same way