### PR TITLE
b41 and b42 are correctly validated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "bitcrypto 0.1.0",
  "chain 0.1.0",
  "keys 0.1.0",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",
  "serialization 0.1.0",
 ]

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -156,6 +156,7 @@ pub fn checksum(data: &[u8]) -> H32 {
 
 #[cfg(test)]
 mod tests {
+	use primitives::bytes::Bytes;
 	use super::{ripemd160, sha1, sha256, dhash160, dhash256, checksum};
 
 	#[test]
@@ -183,6 +184,11 @@ mod tests {
 	fn test_dhash160() {
 		let expected = "b6a9c8c230722b7c748331a8b450f05566dc7d0f".into();
 		let result = dhash160(b"hello");
+		assert_eq!(result, expected);
+
+		let expected = "865c71bfc7e314709207ab9e7e205c6f8e453d08".into();
+		let bytes: Bytes = "210292be03ed9475445cc24a34a115c641a67e4ff234ccb08cb4c5cea45caa526cb26ead6ead6ead6ead6eadac".into();
+		let result = dhash160(&bytes);
 		assert_eq!(result, expected);
 	}
 

--- a/message/src/common/inventory.rs
+++ b/message/src/common/inventory.rs
@@ -77,7 +77,7 @@ mod tests {
 
 	#[test]
 	fn test_inventory_serialize() {
-		let expected = "020000000000000000000000000000000000000000000000000000000000000000000004".into();
+		let expected = "020000000400000000000000000000000000000000000000000000000000000000000000".into();
 
 		let inventory = InventoryVector {
 			inv_type: InventoryType::MessageBlock,
@@ -89,7 +89,7 @@ mod tests {
 
 	#[test]
 	fn test_inventory_deserialize() {
-		let raw: Bytes = "020000000000000000000000000000000000000000000000000000000000000000000004".into();
+		let raw: Bytes = "020000000400000000000000000000000000000000000000000000000000000000000000".into();
 
 		let expected = InventoryVector {
 			inv_type: InventoryType::MessageBlock,

--- a/primitives/src/hash.rs
+++ b/primitives/src/hash.rs
@@ -50,7 +50,7 @@ macro_rules! impl_hash {
 		impl From<u8> for $name {
 			fn from(v: u8) -> Self {
 				let mut result = Self::default();
-				result.0[$size - 1] = v;
+				result.0[0] = v;
 				result
 			}
 		}

--- a/script/Cargo.toml
+++ b/script/Cargo.toml
@@ -9,5 +9,4 @@ chain = { path = "../chain" }
 keys = { path = "../keys" }
 primitives = { path = "../primitives" }
 serialization = { path = "../serialization" }
-
-
+log = "0.3"

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -1895,3 +1895,4 @@ mod tests {
 		assert_eq!(verify_script(&input, &output, &flags, &checker), Err(Error::NumberOverflow));
 	}
 }
+

--- a/script/src/lib.rs
+++ b/script/src/lib.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+extern crate log;
 extern crate bitcrypto as crypto;
 extern crate chain;
 extern crate keys;

--- a/script/src/stack.rs
+++ b/script/src/stack.rs
@@ -88,7 +88,7 @@ impl<T> Stack<T> {
 		try!(self.require(i));
 		let mut j = i;
 		while j > 0 {
-			let v = self.data[self.data.len() - j].clone();
+			let v = self.data[self.data.len() - i].clone();
 			self.data.push(v);
 			j -= 1;
 		}
@@ -263,9 +263,8 @@ mod tests {
 		assert_eq!(stack.dup(2), Ok(()));
 		assert_eq!(stack, vec![0, 0, 0, 0].into());
 		let mut stack: Stack<u8> = vec![0, 1].into();
-		assert_eq!(stack.dup(1), Ok(()));
 		assert_eq!(stack.dup(2), Ok(()));
-		assert_eq!(stack, vec![0, 1, 1, 1, 1].into());
+		assert_eq!(stack, vec![0, 1, 0, 1].into());
 	}
 
 	#[test]


### PR DESCRIPTION
2 bugs are fixed in this pr:

- `OP_DUP` opcode was not working properly
- `TransactionInputSigner` was incorrectly hashing transactions. changed endianness when converting `u8` to hash type
    `H256::from(1)` is now `0100...0000` instead of `0000...0001`

Also fixed added more traces and made few functions more idiomatic