### PR TITLE
Custom data dir command line option

### DIFF
--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -29,6 +29,12 @@ args:
     - printtoconsole:
         long: printtoconsole
         help: Send trace/debug info to console instead of debug.log file
+    - data-dir:
+        short: d
+        long: data-dir
+        value_name: PATH
+        help: Specify the database & configuration directory PATH
+        takes_value: true
     - db-cache:
         long: db-cache
         help: Sets db cache size

--- a/pbtc/commands/start.rs
+++ b/pbtc/commands/start.rs
@@ -10,6 +10,8 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 	let db = open_db(&cfg);
 	try!(init_db(&cfg, &db));
 
+	let nodes_path = node_table_path(&cfg);
+
 	let p2p_cfg = p2p::Config {
 		threads: cfg.p2p_threads,
 		inbound_connections: cfg.inbound_connections,
@@ -26,7 +28,7 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 		},
 		peers: cfg.connect.map_or_else(|| vec![], |x| vec![x]),
 		seeds: cfg.seednode.map_or_else(|| vec![], |x| vec![x]),
-		node_table_path: node_table_path(),
+		node_table_path: nodes_path,
 	};
 
 	let sync_handle = el.handle();

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
 	pub outbound_connections: u32,
 	pub p2p_threads: usize,
 	pub db_cache: usize,
+	pub data_dir: Option<String>,
 }
 
 pub const DEFAULT_DB_CACHE: usize = 512;
@@ -60,6 +61,11 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		None => DEFAULT_DB_CACHE,
 	};
 
+	let data_dir = match matches.value_of("data-dir") {
+		Some(s) => Some(try!(s.parse().map_err(|_| "Invalid data-dir".to_owned()))),
+		None => None,
+	};
+
 	let config = Config {
 		print_to_console: print_to_console,
 		magic: magic,
@@ -70,6 +76,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		outbound_connections: out_connections,
 		p2p_threads: p2p_threads,
 		db_cache: db_cache,
+		data_dir: data_dir,
 	};
 
 	Ok(config)

--- a/pbtc/util.rs
+++ b/pbtc/util.rs
@@ -1,17 +1,23 @@
 use std::sync::Arc;
 use std::path::PathBuf;
+use std::fs::create_dir_all;
 use app_dirs::{app_dir, AppDataType};
-use chain::RepresentH256;
 use {db, APP_INFO};
 use config::Config;
 
 pub fn open_db(cfg: &Config) -> db::SharedStore {
-	let db_path = app_dir(AppDataType::UserData, &APP_INFO, "db").expect("Failed to get app dir");
+	let db_path = match cfg.data_dir {
+		Some(ref data_dir) => custom_path(&data_dir, "db"),
+		None => app_dir(AppDataType::UserData, &APP_INFO, "db").expect("Failed to get app dir"),
+	};
 	Arc::new(db::Storage::with_cache(db_path, cfg.db_cache).expect("Failed to open database"))
 }
 
-pub fn node_table_path() -> PathBuf {
-	let mut node_table = app_dir(AppDataType::UserData, &APP_INFO, "p2p").expect("Failed to get app dir");
+pub fn node_table_path(cfg: &Config) -> PathBuf {
+	let mut node_table = match cfg.data_dir {
+		Some(ref data_dir) => custom_path(&data_dir, "p2p"),
+		None => app_dir(AppDataType::UserData, &APP_INFO, "p2p").expect("Failed to get app dir"),
+	};
 	node_table.push("nodes.csv");
 	node_table
 }
@@ -27,4 +33,13 @@ pub fn init_db(cfg: &Config, db: &db::SharedStore) -> Result<(), String> {
 			Ok(())
 		}
 	}
+}
+
+fn custom_path(data_dir: &str, sub_dir: &str) -> PathBuf {
+	let mut path = PathBuf::from(data_dir);
+	path.push(sub_dir);
+	if let Err(e) = create_dir_all(&path) {
+		panic!("Failed to get app dir: {}", e);
+	}
+	path
 }


### PR DESCRIPTION
Could start > than one pbtc instance. Need this to test synchronization while developing:
```
reset && cargo build --release
mkdir -p ../pbtc_instance1
mkdir -p ../pbtc_instance2
cp target/release/pbtc ../pbtc_instance1
cp target/release/pbtc ../pbtc_instance2
RUST_LOG=sync=info ../pbtc_instance1/pbtc --port 8340 -d ../pbtc_instance1/db -s dnsseed.bluematt.me:8333&
RUST_LOG=sync=info ../pbtc_instance1/pbtc --port 8341 -d ../pbtc_instance2/db -s dnsseed.bluematt.me:8333&
```