### PR TITLE
Increased failure interval to sync later blocks

### DIFF
--- a/sync/src/synchronization_manager.rs
+++ b/sync/src/synchronization_manager.rs
@@ -8,9 +8,9 @@ use primitives::hash::H256;
 /// Management interval (in ms)
 pub const MANAGEMENT_INTERVAL_MS: u64 = 10 * 1000;
 /// Response time before getting block to decrease peer score
-const DEFAULT_PEER_BLOCK_FAILURE_INTERVAL_MS: u32 = 30 * 1000;
+const DEFAULT_PEER_BLOCK_FAILURE_INTERVAL_MS: u32 = 60 * 1000;
 /// Response time before getting inventory to decrease peer score
-const DEFAULT_PEER_INVENTORY_FAILURE_INTERVAL_MS: u32 = 30 * 1000;
+const DEFAULT_PEER_INVENTORY_FAILURE_INTERVAL_MS: u32 = 60 * 1000;
 /// Unknown orphan block removal time
 const DEFAULT_UNKNOWN_BLOCK_REMOVAL_TIME_MS: u32 = 20 * 60 * 1000;
 /// Maximal number of orphaned blocks


### PR DESCRIPTION
When syncing blocks after 200000, it takes too long to request blocks && headers - either some code in sync takes a lot of time, or other peers serve blocks a little bit slower (because they're larger?). I have to learn yet the reason, but to continue sync, let's increase these intervals for now.