### PR TITLE
fix english naming

### DIFF
--- a/db/src/storage.rs
+++ b/db/src/storage.rs
@@ -192,7 +192,7 @@ impl Storage {
 							return Err(Error::double_spend(&input.previous_output.hash));
 						}
 
-						meta.note_used(input.previous_output.index as usize);
+						meta.denote_used(input.previous_output.index as usize);
 						true
 					},
 					None => false,
@@ -204,7 +204,7 @@ impl Storage {
 						return Err(Error::double_spend(&input.previous_output.hash));
 					}
 
-					meta.note_used(input.previous_output.index as usize);
+					meta.denote_used(input.previous_output.index as usize);
 
 					context.meta.insert(
 						input.previous_output.hash.clone(),
@@ -243,7 +243,7 @@ impl Storage {
 			for input in &tx.inputs {
 				if !match context.meta.get_mut(&input.previous_output.hash) {
 					Some(ref mut meta) => {
-						meta.denote_used(input.previous_output.index as usize);
+						meta.denote_unused(input.previous_output.index as usize);
 						true
 					},
 					None => false,
@@ -257,7 +257,7 @@ impl Storage {
 								&input.previous_output.hash
 							));
 
-					meta.denote_used(input.previous_output.index as usize);
+					meta.denote_unused(input.previous_output.index as usize);
 
 					context.meta.insert(
 						input.previous_output.hash.clone(),

--- a/db/src/transaction_meta.rs
+++ b/db/src/transaction_meta.rs
@@ -25,11 +25,6 @@ impl TransactionMeta {
 		}
 	}
 
-	/// note that particular output has been used
-	pub fn note_used(&mut self, index: usize) {
-		self.bits.set(index + 1 , true);
-	}
-
 	pub fn coinbase(mut self) -> Self {
 		self.bits.set(0, true);
 		self
@@ -40,8 +35,13 @@ impl TransactionMeta {
 			.expect("One bit should always exists, since it is created as usize + 1; minimum value of usize is 0; 0 + 1 = 1;  qed")
 	}
 
-	/// note that particular output has been used
+	/// denote particular output as used
 	pub fn denote_used(&mut self, index: usize) {
+		self.bits.set(index + 1 , true);
+	}
+
+	/// denote particular output as not used
+	pub fn denote_unused(&mut self, index: usize) {
 		self.bits.set(index + 1, false);
 	}
 


### PR DESCRIPTION
*denote* - Be a sign of; indicate:

`note_used` -> `denote_used`
`denote_used` -> `denote_unused`