### PR TITLE
verify work and skip timestamp verification on testnet

### DIFF
--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -40,6 +40,8 @@ pub enum Error {
 	Empty,
 	/// Invalid proof-of-work (Block hash does not satisfy nBits)
 	Pow,
+	/// Futuristic timestamp
+	FuturisticTimestamp,
 	/// Invalid timestamp
 	Timestamp,
 	/// First transaction is not a coinbase transaction


### PR DESCRIPTION
changes:

- testnet work is now correctly calculated
- timestamp validation for testnet is temporarily disabled, I do not know what's wrong with it, issue #248