### PR TITLE
fix verification of testnet block 542

### DIFF
--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -57,7 +57,7 @@ pub struct VerificationFlags {
 	/// support CHECKSEQUENCEVERIFY opcode
 	///
 	/// See BIP112 for details
-	pub verify_chechsequenceverify: bool,
+	pub verify_checksequenceverify: bool,
 
 	/// Support segregated witness
 	pub verify_witness: bool,


### PR DESCRIPTION
2 if statements were incorrect

reference to bitcoin implementation of:

- [OP_CHECKSEQUENCEVERIFY](
https://github.com/bitcoin/bitcoin/blob/d612837814020ae832499d18e6ee5eb919a87907/src/script/interpreter.cpp#L378-L383)
- [OP_CHECKLOCKTIMEVERIFY](https://github.com/bitcoin/bitcoin/blob/d612837814020ae832499d18e6ee5eb919a87907/src/script/interpreter.cpp#L335-L342)

fixes #256