### PR TITLE
AsSubstore trait

### DIFF
--- a/db/src/block_provider.rs
+++ b/db/src/block_provider.rs
@@ -33,8 +33,3 @@ pub trait BlockProvider: BlockHeaderProvider {
 	/// returns all transactions in the block by block reference (number/hash)
 	fn block_transactions(&self, block_ref: BlockRef) -> Vec<chain::Transaction>;
 }
-
-pub trait AsBlockHeaderProvider {
-	/// returns `BlockHeaderProvider`
-	fn as_block_header_provider(&self) -> &BlockHeaderProvider;
-}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -67,13 +67,13 @@ impl BlockLocation {
 pub type SharedStore = std::sync::Arc<Store + Send + Sync>;
 
 pub use best_block::BestBlock;
-pub use storage::{Storage, Store};
+pub use storage::{Storage, Store, AsSubstore};
 pub use error::{Error, ConsistencyError};
 pub use kvdb::Database;
-pub use transaction_provider::{TransactionProvider, AsTransactionProvider, PreviousTransactionOutputProvider};
+pub use transaction_provider::{TransactionProvider, PreviousTransactionOutputProvider};
 pub use transaction_meta_provider::TransactionMetaProvider;
 pub use block_stapler::{BlockStapler, BlockInsertedChain};
-pub use block_provider::{BlockProvider, BlockHeaderProvider, AsBlockHeaderProvider};
+pub use block_provider::{BlockProvider, BlockHeaderProvider};
 pub use indexed_block::IndexedBlock;
 pub use indexed_header::IndexedBlockHeader;
 pub use indexed_transaction::IndexedTransaction;

--- a/db/src/test_storage.rs
+++ b/db/src/test_storage.rs
@@ -2,8 +2,8 @@
 
 use super::{
 	BlockRef, Store, Error, BestBlock, BlockLocation, BlockInsertedChain, BlockProvider,
-	BlockStapler, TransactionMetaProvider, TransactionProvider, AsTransactionProvider,
-	IndexedBlock, BlockHeaderProvider, AsBlockHeaderProvider,
+	BlockStapler, TransactionMetaProvider, TransactionProvider,
+	IndexedBlock, BlockHeaderProvider,
 };
 use chain::{self, Block};
 use primitives::hash::H256;
@@ -81,12 +81,6 @@ impl BlockHeaderProvider for TestStorage {
 		self.resolve_hash(block_ref)
 			.and_then(|ref h| data.blocks.get(h))
 			.map(|ref block| block.header().clone())
-	}
-}
-
-impl AsBlockHeaderProvider for TestStorage {
-	fn as_block_header_provider(&self) -> &BlockHeaderProvider {
-		&*self
 	}
 }
 
@@ -189,12 +183,6 @@ impl TransactionProvider for TestStorage {
 		data.blocks.iter().flat_map(|(_, b)| b.transactions())
 			.find(|ref tx| tx.hash() == *hash)
 			.cloned()
-	}
-}
-
-impl AsTransactionProvider for TestStorage {
-	fn as_transaction_provider(&self) -> &TransactionProvider {
-		&*self
 	}
 }
 

--- a/db/src/transaction_provider.rs
+++ b/db/src/transaction_provider.rs
@@ -14,12 +14,6 @@ pub trait TransactionProvider {
 
 	/// resolves serialized transaction info by transaction hash
 	fn transaction(&self, hash: &H256) -> Option<chain::Transaction>;
-
-}
-
-pub trait AsTransactionProvider {
-	/// returns `TransactionProvider`
-	fn as_transaction_provider(&self) -> &TransactionProvider;
 }
 
 /// During transaction the only part of old transaction that we need is `TransactionOutput`.

--- a/miner/src/fee.rs
+++ b/miner/src/fee.rs
@@ -19,7 +19,7 @@ pub fn transaction_fee_rate(store: &TransactionProvider, transaction: &Transacti
 #[cfg(test)]
 mod tests {
 	use std::sync::Arc;
-	use db::{TestStorage, AsTransactionProvider};
+	use db::{TestStorage, AsSubstore};
 	use test_data;
 	use super::*;
 


### PR DESCRIPTION
this pr is a workaround to how rust create it's vtable;

TL;DR traits `AsHeaderProvider` and `AsTransactionProvider` were useless when type is not `Sized` eg. `SharedStore` (which is `Arc<Store>`)

explanation: https://is.gd/GxstCw