### PR TITLE
hash block and transactions while reading them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ name = "db"
 version = "0.1.0"
 dependencies = [
  "bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcrypto 0.1.0",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chain 0.1.0",
  "elastic-array 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -2,11 +2,11 @@ extern crate crypto as rcrypto;
 extern crate primitives;
 extern crate siphasher;
 
+pub use rcrypto::digest::Digest;
 use std::hash::Hasher;
 use rcrypto::sha1::Sha1;
 use rcrypto::sha2::Sha256;
 use rcrypto::ripemd160::Ripemd160;
-use rcrypto::digest::Digest;
 use siphasher::sip::SipHasher24;
 use primitives::hash::{H32, H160, H256};
 
@@ -71,6 +71,12 @@ impl Default for DHash256 {
 impl DHash256 {
 	pub fn new() -> Self {
 		DHash256::default()
+	}
+
+	pub fn finish(mut self) -> H256 {
+		let mut result = H256::default();
+		self.result(&mut *result);
+		result
 	}
 }
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -8,6 +8,7 @@ elastic-array = "0.5"
 rocksdb = { git = "https://github.com/ethcore/rust-rocksdb" }
 ethcore-devtools = { path = "../devtools" }
 primitives = { path = "../primitives" }
+bitcrypto = { path = "../crypto" }
 byteorder = "0.5"
 chain = { path = "../chain"  }
 serialization = { path = "../serialization" }

--- a/db/src/indexed_block.rs
+++ b/db/src/indexed_block.rs
@@ -1,6 +1,10 @@
+use std::io;
 use primitives::hash::H256;
 use chain::{Block, OutPoint, TransactionOutput, merkle_root, Transaction};
-use serialization::{Serializable, serialized_list_size};
+use serialization::{
+	Serializable, serialized_list_size,
+	Deserializable, Reader, Error as ReaderError
+};
 use indexed_header::IndexedBlockHeader;
 use indexed_transaction::IndexedTransaction;
 use {TransactionOutputObserver, PreviousTransactionOutputProvider};
@@ -85,5 +89,16 @@ impl IndexedBlock {
 
 	pub fn is_final(&self, height: u32) -> bool {
 		self.transactions.iter().all(|tx| tx.raw.is_final(height, self.header.raw.time))
+	}
+}
+
+impl Deserializable for IndexedBlock {
+	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
+		let block = IndexedBlock {
+			header: try!(reader.read()),
+			transactions: try!(reader.read_list()),
+		};
+
+		Ok(block)
 	}
 }

--- a/db/src/indexed_header.rs
+++ b/db/src/indexed_header.rs
@@ -1,5 +1,8 @@
+use std::io;
 use primitives::hash::H256;
 use chain::BlockHeader;
+use serialization::{Deserializable, Reader, Error as ReaderError};
+use read_and_hash::ReadAndHash;
 
 #[derive(Debug, Clone)]
 pub struct IndexedBlockHeader {
@@ -22,5 +25,18 @@ impl IndexedBlockHeader {
 			hash: hash,
 			raw: header,
 		}
+	}
+}
+
+impl Deserializable for IndexedBlockHeader {
+	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
+		let data = try!(reader.read_and_hash::<BlockHeader>());
+		// TODO: use len
+		let header = IndexedBlockHeader {
+			raw: data.data,
+			hash: data.hash,
+		};
+
+		Ok(header)
 	}
 }

--- a/db/src/indexed_transaction.rs
+++ b/db/src/indexed_transaction.rs
@@ -1,6 +1,8 @@
-use std::cmp;
+use std::{cmp, io};
 use primitives::hash::H256;
 use chain::{Transaction, OutPoint, TransactionOutput};
+use serialization::{Deserializable, Reader, Error as ReaderError};
+use read_and_hash::ReadAndHash;
 use PreviousTransactionOutputProvider;
 
 #[derive(Debug, Clone)]
@@ -30,6 +32,19 @@ impl IndexedTransaction {
 impl cmp::PartialEq for IndexedTransaction {
 	fn eq(&self, other: &Self) -> bool {
 		self.hash == other.hash
+	}
+}
+
+impl Deserializable for IndexedTransaction {
+	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
+		let data = try!(reader.read_and_hash::<Transaction>());
+		// TODO: use len
+		let tx = IndexedTransaction {
+			raw: data.data,
+			hash: data.hash,
+		};
+
+		Ok(tx)
 	}
 }
 

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,5 +1,6 @@
 //! Bitcoin database
 
+extern crate bitcrypto as crypto;
 extern crate elastic_array;
 extern crate rocksdb;
 extern crate parking_lot;
@@ -31,6 +32,7 @@ mod update_context;
 mod indexed_block;
 mod indexed_header;
 mod indexed_transaction;
+mod read_and_hash;
 
 #[derive(Debug, Clone)]
 pub enum BlockRef {

--- a/db/src/read_and_hash.rs
+++ b/db/src/read_and_hash.rs
@@ -1,0 +1,33 @@
+use std::io;
+use crypto::{DHash256, Digest};
+use primitives::hash::H256;
+use serialization::{Reader, Error as ReaderError, Deserializable};
+
+pub struct HashedData<T> {
+	pub len: usize,
+	pub hash: H256,
+	pub data: T,
+}
+
+pub trait ReadAndHash {
+	fn read_and_hash<T>(&mut self) -> Result<HashedData<T>, ReaderError> where T: Deserializable;
+}
+
+impl<R> ReadAndHash for Reader<R> where R: io::Read {
+	fn read_and_hash<T>(&mut self) -> Result<HashedData<T>, ReaderError> where T: Deserializable {
+		let mut len = 0usize;
+		let mut hasher = DHash256::new();
+		let data = self.read_with_proxy(|bytes| {
+			len += bytes.len();
+			hasher.input(bytes);
+		})?;
+
+		let result = HashedData {
+			hash: hasher.finish(),
+			data: data,
+			len: len,
+		};
+
+		Ok(result)
+	}
+}


### PR DESCRIPTION
this is a foundation of a potentially quite big optimization. it introduces:
- hashing transactions and blocks while reading them (so we do not need to serialize them again)
- counting their size while deserializing (so we do not need to serialize them again ;)

code from this pr is not used yet, but we may use it for #318

* I know it is not a scope of miner, but it was just to tempting to implement ;)