### PR TITLE
Move overflow checks into separate error type

### DIFF
--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -36,6 +36,10 @@ pub enum Error {
 	NonFinalBlock,
 	/// Old version block.
 	OldVersionBlock,
+	/// Sum of the transaction fees in block + coinbase reward exceeds u64::max
+	TransactionFeeAndRewardOverflow,
+	/// Sum of the transaction fees in block exceeds u64::max
+	TransactionFeesOverflow,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
otherwise verification can fail with pretty weird message: 

```
verifier::main: thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CoinbaseOverspend { expected_max: 4990000000, actual: 10 }', ../src/libcore/result.rs:837
```