### PR TITLE
Temporary switched to github version of tokio-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,6 @@ dependencies = [
  "db 0.1.0",
  "ethcore-devtools 1.3.0",
  "futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "message 0.1.0",
@@ -1009,7 +1008,6 @@ dependencies = [
  "serialization 0.1.0",
  "test-data 0.1.0",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "verification 0.1.0",
 ]
 
@@ -1118,7 +1116,7 @@ dependencies = [
 [[package]]
 name = "tokio-core"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tokio-rs/tokio-core.git?rev=d0833074d6c47970b69baf69702c92a497c93fc2#d0833074d6c47970b69baf69702c92a497c93fc2"
 dependencies = [
  "futures 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1126,6 +1124,12 @@ dependencies = [
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "tokio-core"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+replace = "tokio-core 0.1.3 (git+https://github.com/tokio-rs/tokio-core.git?rev=d0833074d6c47970b69baf69702c92a497c93fc2)"
 
 [[package]]
 name = "unicase"
@@ -1323,6 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
+"checksum tokio-core 0.1.3 (git+https://github.com/tokio-rs/tokio-core.git?rev=d0833074d6c47970b69baf69702c92a497c93fc2)" = "<none>"
 "checksum tokio-core 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0800e9475303171ffbc79394079ef503b6d00949649799208f4fc8f1eca20892"
 "checksum unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a5906ca2b98c799f4b1ab4557b76367ebd6ae5ef14930ec841c74aed5f3764"
 "checksum unicode-bidi 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b61814f3e7fd0e0f15370f767c7c943e08bc2e3214233ae8f88522b334ceb778"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ logs = { path = "logs" }
 rpc = { path = "rpc" }
 primitives = { path = "primitives" }
 
+# remove me after new version of tokio-core is released + run cargo update
+[replace]
+"tokio-core:0.1.3" = { git = "https://github.com/tokio-rs/tokio-core.git", rev = "d0833074d6c47970b69baf69702c92a497c93fc2" }
+
 [[bin]]
 path = "pbtc/main.rs"
 name = "pbtc"

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -8,8 +8,6 @@ parking_lot = "0.3"
 log = "0.3"
 time = "0.1"
 futures = "0.1"
-futures-cpupool = "0.1"
-tokio-core = "0.1"
 linked-hash-map = "0.3"
 ethcore-devtools = { path = "../devtools" }
 bit-vec = "0.4.3"

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -5,8 +5,6 @@ extern crate db;
 #[macro_use]
 extern crate log;
 extern crate futures;
-extern crate futures_cpupool;
-extern crate tokio_core;
 extern crate message;
 extern crate p2p;
 extern crate parking_lot;


### PR DESCRIPTION
+ also removed obsolete dependencies of sync 
closes #353  