### PR TITLE
keys::Address remote serialization

### DIFF
--- a/keys/src/address.rs
+++ b/keys/src/address.rs
@@ -28,7 +28,7 @@ pub enum Type {
 }
 
 /// `AddressHash` with network identifier and format type
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Address {
 	/// The type of the address.
 	pub kind: Type,

--- a/rpc/src/v1/impls/raw.rs
+++ b/rpc/src/v1/impls/raw.rs
@@ -55,9 +55,9 @@ impl RawClientCore {
 			.map(|output| match output {
 					TransactionOutput::Address(with_address) => {
 						let amount_in_satoshis = (with_address.amount * (chain::constants::SATOSHIS_IN_COIN as f64)) as u64;
-						let script = match (*with_address.address).kind {
-							keys::Type::P2PKH => ScriptBuilder::build_p2pkh(&(*with_address.address).hash),
-							keys::Type::P2SH => ScriptBuilder::build_p2sh(&(*with_address.address).hash),
+						let script = match with_address.address.kind {
+							keys::Type::P2PKH => ScriptBuilder::build_p2pkh(&with_address.address.hash),
+							keys::Type::P2SH => ScriptBuilder::build_p2sh(&with_address.address.hash),
 						};
 
 						chain::TransactionOutput {

--- a/rpc/src/v1/types/address.rs
+++ b/rpc/src/v1/types/address.rs
@@ -1,92 +1,78 @@
-use std::{ops, fmt};
-use std::str::FromStr;
-use serde::{Serialize, Deserialize, Serializer, Deserializer};
-use serde::de::{Visitor, Unexpected, Expected};
-use global_script::ScriptAddress;
-use keys::Address as GlobalAddress;
-use keys::Network as KeysNetwork;
-use network::Magic;
+use std::fmt;
+use serde::{Serialize, Serializer, Deserializer};
+use serde::de::{Visitor, Unexpected};
+use keys::Address;
 
-/// Bitcoin address
-#[derive(Debug, PartialEq)]
-pub struct Address(GlobalAddress);
+pub fn serialize<S>(address: &Address, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+	address.to_string().serialize(serializer)
+}
 
-impl Address {
-	pub fn new(network: Magic, address: ScriptAddress) -> Self {
-		Address(GlobalAddress {
-			network: match network {
-				Magic::Mainnet => KeysNetwork::Mainnet,
-				// there's no correct choices for Regtests && Other networks
-				// => let's just make Testnet key
-				_ => KeysNetwork::Testnet,
-			},
-			hash: address.hash,
-			kind: address.kind,
-		})
+pub fn deserialize<'a, D>(deserializer: D) -> Result<Address, D::Error> where D: Deserializer<'a> {
+	deserializer.deserialize_any(AddressVisitor)
+}
+
+#[derive(Default)]
+pub struct AddressVisitor;
+
+impl<'b> Visitor<'b> for AddressVisitor {
+	type Value = Address;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str("an address")
 	}
 
-	pub fn deserialize_from_string<E>(value: &str, expected: &Expected) -> Result<Address, E> where E: ::serde::de::Error {
- 		GlobalAddress::from_str(value)
-			.map(Address)
-			.map_err(|_| E::invalid_value(Unexpected::Str(value), expected))
+	fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> where E: ::serde::de::Error {
+		value.parse().map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
 	}
 }
 
-impl Serialize for Address {
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-		serializer.serialize_str(&self.0.to_string())
+pub mod vec {
+	use serde::{Serialize, Serializer, Deserializer, Deserialize};
+	use serde::de::Visitor;
+	use keys::Address;
+	use super::AddressVisitor;
+
+	pub fn serialize<S>(addresses: &Vec<Address>, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+		addresses.iter().map(|address| address.to_string()).collect::<Vec<_>>().serialize(serializer)
 	}
-}
 
-impl<'a> Deserialize<'a> for Address {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'a> {
-		struct AddressVisitor;
-
-		impl<'b> Visitor<'b> for AddressVisitor {
-			type Value = Address;
-
-			fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-				formatter.write_str("an address")
-			}
-
-			fn visit_str<E>(self, value: &str) -> Result<Address, E> where E: ::serde::de::Error {
-				Address::deserialize_from_string(value, &self)
-			}
-		}
-
-		deserializer.deserialize_identifier(AddressVisitor)
-	}
-}
-
-impl<T> From<T> for Address where GlobalAddress: From<T> {
-	fn from(o: T) -> Self {
-		Address(GlobalAddress::from(o))
-	}
-}
-
-impl ops::Deref for Address {
-	type Target = GlobalAddress;
-
-	fn deref(&self) -> &Self::Target {
-		&self.0
+	pub fn deserialize<'a, D>(deserializer: D) -> Result<Vec<Address>, D::Error> where D: Deserializer<'a> {
+		<Vec<&'a str> as Deserialize>::deserialize(deserializer)?
+			.into_iter()
+			.map(|value| AddressVisitor::default().visit_str(value))
+			.collect()
 	}
 }
 
 #[cfg(test)]
 mod tests {
 	use serde_json;
-	use super::Address;
+	use keys::Address;
+	use v1::types;
+
+	#[derive(Debug, PartialEq, Serialize, Deserialize)]
+	struct TestStruct {
+		#[serde(with = "types::address")]
+		address: Address,
+	}
+
+	impl TestStruct {
+		fn new(address: Address) -> Self {
+			TestStruct {
+				address: address,
+			}
+		}
+	}
 
 	#[test]
 	fn address_serialize() {
-		let address: Address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".into();
-		assert_eq!(serde_json::to_string(&address).unwrap(), r#""1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa""#);
+		let test = TestStruct::new("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".into());
+		assert_eq!(serde_json::to_string(&test).unwrap(), r#"{"address":"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"}"#);
 	}
 
 	#[test]
 	fn address_deserialize() {
-		let address: Address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".into();
-		assert_eq!(serde_json::from_str::<Address>(r#""1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa""#).unwrap(), address);
-		assert!(serde_json::from_str::<Address>(r#""DEADBEEF""#).is_err());
+		let test = TestStruct::new("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".into());
+		assert_eq!(serde_json::from_str::<TestStruct>(r#"{"address":"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"}"#).unwrap(), test);
 	}
 }

--- a/rpc/src/v1/types/mod.rs
+++ b/rpc/src/v1/types/mod.rs
@@ -1,4 +1,4 @@
-mod address;
+pub mod address;
 mod block;
 mod block_template;
 mod block_template_request;
@@ -12,7 +12,6 @@ mod transaction;
 mod uint;
 mod nodes;
 
-pub use self::address::Address;
 pub use self::block::RawBlock;
 pub use self::block_template::{BlockTemplate, BlockTemplateTransaction};
 pub use self::block_template_request::{BlockTemplateRequest, BlockTemplateRequestMode};


### PR DESCRIPTION
This pr can be a prelude to simplifying rpc serialization.

It uses field attribute `#[serde(with = "module")]` ([docs](https://serde.rs/field-attrs.html)), but serialization can be also simplified using `#[serde(remote = "...")]` ([docs](https://github.com/serde-rs/serde/releases/tag/v1.0.0))

Please tell me what you think about it