### PR TITLE
Add nulldata builder and fix op_return script push

### DIFF
--- a/script/src/builder.rs
+++ b/script/src/builder.rs
@@ -102,7 +102,16 @@ impl Builder {
 
 	/// Appends `OP_RETURN` operation to the end of script
 	pub fn return_bytes(mut self, bytes: &[u8]) -> Self {
+		let len = bytes.len();
+		if len < 1 || len > 75 {
+			panic!(format!("Canot push {} bytes", len));
+		}
+
+		let opcode: Opcode = Opcode::from_u8(((Opcode::OP_PUSHBYTES_1 as usize) + len - 1) as u8)
+			.expect("value is within [OP_PUSHBYTES_1; OP_PUSHBYTES_75] interval; qed");
+
 		self.data.push(Opcode::OP_RETURN as u8);
+		self.data.push(opcode as u8);
 		self.data.extend_from_slice(bytes);
 		self
 	}

--- a/script/src/builder.rs
+++ b/script/src/builder.rs
@@ -31,6 +31,14 @@ impl Builder {
 			.into_script()
 	}
 
+	/// Builds op_return script
+	pub fn build_nulldata(bytes: &[u8]) -> Script {
+		Builder::default()
+			.push_opcode(Opcode::OP_RETURN)
+			.push_bytes(bytes)
+			.into_script()
+	}
+
 	/// Pushes opcode to the end of script
 	pub fn push_opcode(mut self, opcode: Opcode) -> Self {
 		self.data.push(opcode as u8);


### PR DESCRIPTION
It would be very handy to have a builder for nulldata scripts, hence the nulldata builder. It is useful also to avoid having developers risk to make it in the wrong way.

The return_bytes function does not follow the rules for building op_return scripts, which are followed by is_nulldata. I've updated the function to make it compliant with what is_nulldata expect, with the minimum modifications required.