### PR TITLE
Add build-essential install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ curl -sSf https://static.rust-lang.org/rustup.sh | sh
 
 Windows binaries can be downloaded from [rust-lang website](https://www.rust-lang.org/en-US/downloads.html).
 
+#### Install C and C++ compilers
+
+You will need the gcc and cc compilers to build some of the dependencies
+
+```
+sudo apt-get update
+sudo apt-get install build-essential
+```
+
 #### Clone and build pbtc
 
 Now let's clone `pbtc` and enter it's directory

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Windows binaries can be downloaded from [rust-lang website](https://www.rust-lan
 
 #### Install C and C++ compilers
 
-You will need the gcc and cc compilers to build some of the dependencies
+You will need the cc and gcc compilers to build some of the dependencies
 
 ```
 sudo apt-get update


### PR DESCRIPTION
I was trying to install this with a fresh Ubuntu 16.04 image and it kept failing on trying to install the `heapsize` dependency. Turned out I needed to install build-essentials with the cc and gcc compilers in order to build all of the dependencies. This was the only package I needed to install to successfully build `pbtc` in debug mode