### PR TITLE
Add the packaging metadata to build the parity-bitcoin snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: parity-bitcoin
+version: git
+summary: The Parity Bitcoin client
+description: |
+  Bitcoin client written in Rust.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  parity-bitcoin:
+    command: pbtc
+    plugs: [network, network-bind]
+
+parts:
+  parity-bitcoin:
+    source: .
+    plugin: rust
+    build-packages: [g++]


### PR DESCRIPTION
This package will let you publish the latest parity-bitcoin in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress.