### PR TITLE
custom serialization preprocessor macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "network 0.1.0",
  "primitives 0.1.0",
  "serialization 0.1.0",
+ "serialization_derive 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serialization_derive"
+version = "0.1.0"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serialization 0.1.0",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "primitives 0.1.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serialization 0.1.0",
+ "serialization_derive 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ path = "pbtc/main.rs"
 name = "pbtc"
 
 [workspace]
-members = ["bencher"]
+members = ["bencher", "serialization_derive"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ path = "pbtc/main.rs"
 name = "pbtc"
 
 [workspace]
-members = ["bencher", "serialization_derive"]
+members = ["bencher"]

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -9,4 +9,5 @@ heapsize = "0.3"
 bitcrypto = { path = "../crypto" }
 primitives = { path = "../primitives" }
 serialization = { path = "../serialization" }
+serialization_derive = { path = "../serialization_derive" }
 

--- a/chain/src/block.rs
+++ b/chain/src/block.rs
@@ -1,37 +1,14 @@
-use std::io;
 use hex::FromHex;
 use hash::H256;
-use ser::{
-	Deserializable, Reader, Error as ReaderError, deserialize,
-	Serializable, Stream
-};
+use ser::{deserialize};
 use merkle_root::merkle_root;
 use {BlockHeader, Transaction};
 use super::RepresentH256;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serializable, Deserializable)]
 pub struct Block {
 	pub block_header: BlockHeader,
 	pub transactions: Vec<Transaction>,
-}
-
-impl Serializable for Block {
-	fn serialize(&self, stream: &mut Stream) {
-		stream
-			.append(&self.block_header)
-			.append_list(&self.transactions);
-	}
-}
-
-impl Deserializable for Block {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let result = Block {
-			block_header: try!(reader.read()),
-			transactions: try!(reader.read_list()),
-		};
-
-		Ok(result)
-	}
 }
 
 impl From<&'static str> for Block {

--- a/chain/src/block_header.rs
+++ b/chain/src/block_header.rs
@@ -1,14 +1,11 @@
-use std::{fmt, io};
+use std::fmt;
 use hex::FromHex;
-use ser::{
-	Deserializable, Reader, Error as ReaderError, deserialize,
-	Serializable, Stream, serialize
-};
+use ser::{deserialize, serialize};
 use crypto::dhash256;
 use compact::Compact;
 use hash::H256;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Serializable, Deserializable)]
 pub struct BlockHeader {
 	pub version: u32,
 	pub previous_header_hash: H256,
@@ -34,33 +31,6 @@ impl fmt::Debug for BlockHeader {
 			.field("bits", &self.bits)
 			.field("nonce", &self.nonce)
 			.finish()
-	}
-}
-
-impl Serializable for BlockHeader {
-	fn serialize(&self, stream: &mut Stream) {
-		stream
-			.append(&self.version)
-			.append(&self.previous_header_hash)
-			.append(&self.merkle_root_hash)
-			.append(&self.time)
-			.append(&self.bits)
-			.append(&self.nonce);
-	}
-}
-
-impl Deserializable for BlockHeader {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let block_header = BlockHeader {
-			version: try!(reader.read()),
-			previous_header_hash: try!(reader.read()),
-			merkle_root_hash: try!(reader.read()),
-			time: try!(reader.read()),
-			bits: try!(reader.read()),
-			nonce: try!(reader.read()),
-		};
-
-		Ok(block_header)
 	}
 }
 

--- a/chain/src/indexed_block.rs
+++ b/chain/src/indexed_block.rs
@@ -1,17 +1,14 @@
-use std::{io, cmp};
+use std::cmp;
 use hash::H256;
 use hex::FromHex;
-use ser::{
-	Serializable, serialized_list_size,
-	Deserializable, Reader, Error as ReaderError, deserialize
-};
+use ser::{Serializable, serialized_list_size, deserialize};
 use block::Block;
 use transaction::Transaction;
 use merkle_root::merkle_root;
 use indexed_header::IndexedBlockHeader;
 use indexed_transaction::IndexedTransaction;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserializable)]
 pub struct IndexedBlock {
 	pub header: IndexedBlockHeader,
 	pub transactions: Vec<IndexedTransaction>,
@@ -63,17 +60,6 @@ impl IndexedBlock {
 
 	pub fn is_final(&self, height: u32) -> bool {
 		self.transactions.iter().all(|tx| tx.raw.is_final_in_block(height, self.header.raw.time))
-	}
-}
-
-impl Deserializable for IndexedBlock {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let block = IndexedBlock {
-			header: try!(reader.read()),
-			transactions: try!(reader.read_list()),
-		};
-
-		Ok(block)
 	}
 }
 

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -3,6 +3,8 @@ extern crate heapsize;
 extern crate primitives;
 extern crate bitcrypto as crypto;
 extern crate serialization as ser;
+#[macro_use]
+extern crate serialization_derive;
 
 pub mod constants;
 

--- a/message/Cargo.toml
+++ b/message/Cargo.toml
@@ -10,4 +10,5 @@ bitcrypto = { path = "../crypto" }
 chain = { path = "../chain" }
 primitives = { path = "../primitives" }
 serialization = { path = "../serialization" }
+serialization_derive = { path = "../serialization_derive" }
 network = { path = "../network" }

--- a/message/src/common/address.rs
+++ b/message/src/common/address.rs
@@ -1,36 +1,12 @@
-use std::io;
 use bytes::Bytes;
-use ser::{
-	Stream, Serializable,
-	Reader, Deserializable, Error as ReaderError, deserialize,
-};
+use ser::deserialize;
 use common::{Port, IpAddress, Services};
 
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone, Serializable, Deserializable)]
 pub struct NetAddress {
 	pub services: Services,
 	pub address: IpAddress,
 	pub port: Port,
-}
-
-impl Serializable for NetAddress {
-	fn serialize(&self, stream: &mut Stream) {
-		stream
-			.append(&self.services)
-			.append(&self.address)
-			.append(&self.port);
-	}
-}
-
-impl Deserializable for NetAddress {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let net = NetAddress {
-			services: try!(reader.read()),
-			address: try!(reader.read()),
-			port: try!(reader.read()),
-		};
-		Ok(net)
-	}
 }
 
 impl From<&'static str> for NetAddress {

--- a/message/src/common/block_header_and_ids.rs
+++ b/message/src/common/block_header_and_ids.rs
@@ -1,35 +1,10 @@
-use std::io;
-use ser::{Serializable, Stream, Deserializable, Reader, Error as ReaderError};
 use chain::{BlockHeader, ShortTransactionID};
 use common::PrefilledTransaction;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serializable, Deserializable)]
 pub struct BlockHeaderAndIDs {
 	pub header: BlockHeader,
 	pub nonce: u64,
 	pub short_ids: Vec<ShortTransactionID>,
 	pub prefilled_transactions: Vec<PrefilledTransaction>,
-}
-
-impl Serializable for BlockHeaderAndIDs {
-	fn serialize(&self, stream: &mut Stream) {
-		stream
-			.append(&self.header)
-			.append(&self.nonce)
-			.append_list(&self.short_ids)
-			.append_list(&self.prefilled_transactions);
-	}
-}
-
-impl Deserializable for BlockHeaderAndIDs {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let header= BlockHeaderAndIDs {
-			header: try!(reader.read()),
-			nonce: try!(reader.read()),
-			short_ids: try!(reader.read_list()),
-			prefilled_transactions: try!(reader.read_list()),
-		};
-
-		Ok(header)
-	}
 }

--- a/message/src/common/block_transactions.rs
+++ b/message/src/common/block_transactions.rs
@@ -1,29 +1,8 @@
-use std::io;
 use hash::H256;
-use ser::{Serializable, Stream, Deserializable, Reader, Error as ReaderError};
 use chain::Transaction;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serializable, Deserializable)]
 pub struct BlockTransactions {
 	pub blockhash: H256,
 	pub transactions: Vec<Transaction>,
-}
-
-impl Serializable for BlockTransactions {
-	fn serialize(&self, stream: &mut Stream) {
-		stream
-			.append(&self.blockhash)
-			.append_list(&self.transactions);
-	}
-}
-
-impl Deserializable for BlockTransactions {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		let block_transactions = BlockTransactions {
-			blockhash: try!(reader.read()),
-			transactions: try!(reader.read_list()),
-		};
-
-		Ok(block_transactions)
-	}
 }

--- a/message/src/common/command.rs
+++ b/message/src/common/command.rs
@@ -1,10 +1,9 @@
-use std::{str, fmt, io};
+use std::{str, fmt};
 use std::ascii::AsciiExt;
 use hash::H96;
-use ser::{Serializable, Stream, Deserializable, Reader, Error as ReaderError};
 use Error;
 
-#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq, Serializable, Deserializable)]
 pub struct Command(H96);
 
 impl str::FromStr for Command {
@@ -51,18 +50,6 @@ impl From<Command> for String {
 impl fmt::Display for Command {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(&self.as_string())
-	}
-}
-
-impl Serializable for Command {
-	fn serialize(&self, stream: &mut Stream) {
-		stream.append(&self.0);
-	}
-}
-
-impl Deserializable for Command {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		reader.read().map(Command)
 	}
 }
 

--- a/message/src/common/service.rs
+++ b/message/src/common/service.rs
@@ -1,10 +1,4 @@
-use std::io;
-use ser::{
-	Serializable, Stream,
-	Deserializable, Reader, Error as ReaderError
-};
-
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serializable, Deserializable)]
 pub struct Services(u64);
 
 impl From<Services> for u64 {
@@ -79,18 +73,6 @@ impl Services {
 
 	fn bit_at(&self, bit: usize) -> bool {
 		self.0 & (1 << bit) != 0
-	}
-}
-
-impl Serializable for Services {
-	fn serialize(&self, stream: &mut Stream) {
-		stream.append(&self.0);
-	}
-}
-
-impl Deserializable for Services {
-	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
-		reader.read().map(Services)
 	}
 }
 

--- a/message/src/lib.rs
+++ b/message/src/lib.rs
@@ -3,6 +3,8 @@ extern crate bitcrypto as crypto;
 extern crate chain;
 extern crate primitives;
 extern crate serialization as ser;
+#[macro_use]
+extern crate serialization_derive;
 extern crate network;
 
 pub mod common;

--- a/serialization_derive/Cargo.toml
+++ b/serialization_derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "serialization_derive"
+version = "0.1.0"
+authors = ["debris <marek.kotewicz@gmail.com>"]
+
+[lib]
+name = "serialization_derive"
+proc-macro = true
+
+[dependencies]
+syn = "0.11.11"
+quote = "0.3.15"
+serialization = { path = "../serialization" }

--- a/serialization_derive/Cargo.toml
+++ b/serialization_derive/Cargo.toml
@@ -10,4 +10,6 @@ proc-macro = true
 [dependencies]
 syn = "0.11.11"
 quote = "0.3.15"
+
+[dev-dependencies]
 serialization = { path = "../serialization" }

--- a/serialization_derive/src/de.rs
+++ b/serialization_derive/src/de.rs
@@ -1,20 +1,20 @@
 use {syn, quote};
 
-pub fn impl_raw_deserialize(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn impl_deserializable(ast: &syn::DeriveInput) -> quote::Tokens {
 	let body = match ast.body {
 		syn::Body::Struct(ref s) => s,
-		_ => panic!("#[derive(RawDeserialize)] is only defined for structs."),
+		_ => panic!("#[derive(Deserializable)] is only defined for structs."),
 	};
 
 	let stmts: Vec<_> = match *body {
 		syn::VariantData::Struct(ref fields) => fields.iter().enumerate().map(deserialize_field_map).collect(),
 		syn::VariantData::Tuple(ref fields) => fields.iter().enumerate().map(deserialize_field_map).collect(),
-		syn::VariantData::Unit => panic!("#[derive(RawDeserialize)] is not defined for Unit structs."),
+		syn::VariantData::Unit => panic!("#[derive(Deserializable)] is not defined for Unit structs."),
 	};
 
 	let name = &ast.ident;
 
-	let dummy_const = syn::Ident::new(format!("_IMPL_RAW_DESERIALIZE_FOR_{}", name));
+	let dummy_const = syn::Ident::new(format!("_IMPL_DESERIALIZABLE_FOR_{}", name));
 	let impl_block = quote! {
 		impl serialization::Deserializable for #name {
 			fn deserialize<T>(reader: &mut serialization::Reader<T>) -> Result<Self, serialization::Error> where T: io::Read {

--- a/serialization_derive/src/de.rs
+++ b/serialization_derive/src/de.rs
@@ -1,0 +1,64 @@
+use {syn, quote};
+
+pub fn impl_raw_deserialize(ast: &syn::DeriveInput) -> quote::Tokens {
+	let body = match ast.body {
+		syn::Body::Struct(ref s) => s,
+		_ => panic!("#[derive(RawDeserialize)] is only defined for structs."),
+	};
+
+	let stmts: Vec<_> = match *body {
+		syn::VariantData::Struct(ref fields) => fields.iter().enumerate().map(deserialize_field_map).collect(),
+		syn::VariantData::Tuple(ref fields) => fields.iter().enumerate().map(deserialize_field_map).collect(),
+		syn::VariantData::Unit => panic!("#[derive(RawDeserialize)] is not defined for Unit structs."),
+	};
+
+	let name = &ast.ident;
+
+	let dummy_const = syn::Ident::new(format!("_IMPL_RAW_DESERIALIZE_FOR_{}", name));
+	let impl_block = quote! {
+		impl serialization::Deserializable for #name {
+			fn deserialize<T>(reader: &mut serialization::Reader<T>) -> Result<Self, serialization::Error> where T: io::Read {
+				let result = #name {
+					#(#stmts)*
+				};
+
+				Ok(result)
+			}
+		}
+	};
+
+	quote! {
+		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+		const #dummy_const: () = {
+			extern crate serialization;
+			use std::io;
+			#impl_block
+		};
+	}
+}
+
+fn deserialize_field_map(tuple: (usize, &syn::Field)) -> quote::Tokens {
+	deserialize_field(tuple.0, tuple.1)
+}
+
+fn deserialize_field(index: usize, field: &syn::Field) -> quote::Tokens {
+	let ident = match field.ident {
+		Some(ref ident) => ident.to_string(),
+		None => index.to_string(),
+	};
+
+	let id = syn::Ident::new(ident.to_string());
+
+	match field.ty {
+		syn::Ty::Array(_, _) => quote! { #id: reader.read_list()?, },
+		syn::Ty::Slice(_) => quote! { #id: reader.read_list()?, },
+		syn::Ty::Path(_, ref path) => {
+			let ident = &path.segments.first().expect("there must be at least 1 segment").ident;
+			match &ident.to_string() as &str {
+				"Vec" => quote! { #id: reader.read_list()?, },
+				_ => quote! { #id: reader.read()?, },
+			}
+		},
+		_ => quote! { #id: reader.read()?, },
+	}
+}

--- a/serialization_derive/src/de.rs
+++ b/serialization_derive/src/de.rs
@@ -50,15 +50,14 @@ fn deserialize_field(index: usize, field: &syn::Field) -> quote::Tokens {
 	let id = syn::Ident::new(ident.to_string());
 
 	match field.ty {
-		syn::Ty::Array(_, _) => quote! { #id: reader.read_list()?, },
-		syn::Ty::Slice(_) => quote! { #id: reader.read_list()?, },
 		syn::Ty::Path(_, ref path) => {
 			let ident = &path.segments.first().expect("there must be at least 1 segment").ident;
-			match &ident.to_string() as &str {
-				"Vec" => quote! { #id: reader.read_list()?, },
-				_ => quote! { #id: reader.read()?, },
+			if &ident.to_string() == "Vec" {
+				quote! { #id: reader.read_list()?, }
+			} else {
+				quote! { #id: reader.read()?, }
 			}
 		},
-		_ => quote! { #id: reader.read()?, },
+		_ => panic!("serialization not supported"),
 	}
 }

--- a/serialization_derive/src/lib.rs
+++ b/serialization_derive/src/lib.rs
@@ -1,0 +1,28 @@
+extern crate proc_macro;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+mod ser;
+mod de;
+
+use proc_macro::TokenStream;
+use ser::impl_raw_serialize;
+use de::impl_raw_deserialize;
+
+#[proc_macro_derive(RawSerialize)]
+pub fn raw_serialize(input: TokenStream) -> TokenStream {
+	let s = input.to_string();
+	let ast = syn::parse_derive_input(&s).unwrap();
+	let gen = impl_raw_serialize(&ast);
+	gen.parse().unwrap()
+}
+
+#[proc_macro_derive(RawDeserialize)]
+pub fn raw_deserialize(input: TokenStream) -> TokenStream {
+	let s = input.to_string();
+	let ast = syn::parse_derive_input(&s).unwrap();
+	let gen = impl_raw_deserialize(&ast);
+	gen.parse().unwrap()
+}
+

--- a/serialization_derive/src/lib.rs
+++ b/serialization_derive/src/lib.rs
@@ -11,7 +11,7 @@ use ser::impl_serializable;
 use de::impl_deserializable;
 
 #[proc_macro_derive(Serializable)]
-pub fn raw_serialize(input: TokenStream) -> TokenStream {
+pub fn serializable(input: TokenStream) -> TokenStream {
 	let s = input.to_string();
 	let ast = syn::parse_derive_input(&s).unwrap();
 	let gen = impl_serializable(&ast);

--- a/serialization_derive/src/lib.rs
+++ b/serialization_derive/src/lib.rs
@@ -7,22 +7,22 @@ mod ser;
 mod de;
 
 use proc_macro::TokenStream;
-use ser::impl_raw_serialize;
-use de::impl_raw_deserialize;
+use ser::impl_serializable;
+use de::impl_deserializable;
 
-#[proc_macro_derive(RawSerialize)]
+#[proc_macro_derive(Serializable)]
 pub fn raw_serialize(input: TokenStream) -> TokenStream {
 	let s = input.to_string();
 	let ast = syn::parse_derive_input(&s).unwrap();
-	let gen = impl_raw_serialize(&ast);
+	let gen = impl_serializable(&ast);
 	gen.parse().unwrap()
 }
 
-#[proc_macro_derive(RawDeserialize)]
-pub fn raw_deserialize(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(Deserializable)]
+pub fn deserializable(input: TokenStream) -> TokenStream {
 	let s = input.to_string();
 	let ast = syn::parse_derive_input(&s).unwrap();
-	let gen = impl_raw_deserialize(&ast);
+	let gen = impl_deserializable(&ast);
 	gen.parse().unwrap()
 }
 

--- a/serialization_derive/src/ser.rs
+++ b/serialization_derive/src/ser.rs
@@ -1,20 +1,20 @@
 use {syn, quote};
 
-pub fn impl_raw_serialize(ast: &syn::DeriveInput) -> quote::Tokens {
+pub fn impl_serializable(ast: &syn::DeriveInput) -> quote::Tokens {
 	let body = match ast.body {
 		syn::Body::Struct(ref s) => s,
-		_ => panic!("#[derive(RawSerialize)] is only defined for structs."),
+		_ => panic!("#[derive(Serializable)] is only defined for structs."),
 	};
 
 	let stmts: Vec<_> = match *body {
 		syn::VariantData::Struct(ref fields) => fields.iter().enumerate().map(serialize_field_map).collect(),
 		syn::VariantData::Tuple(ref fields) => fields.iter().enumerate().map(serialize_field_map).collect(),
-		syn::VariantData::Unit => panic!("#[derive(RawSerialize)] is not defined for Unit structs."),
+		syn::VariantData::Unit => panic!("#[derive(Serializable)] is not defined for Unit structs."),
 	};
 
 	let name = &ast.ident;
 
-	let dummy_const = syn::Ident::new(format!("_IMPL_RAW_SERIALIZE_FOR_{}", name));
+	let dummy_const = syn::Ident::new(format!("_IMPL_SERIALIZABLE_FOR_{}", name));
 	let impl_block = quote! {
 		impl serialization::Serializable for #name {
 			fn serialize(&self, stream: &mut serialization::Stream) {

--- a/serialization_derive/src/ser.rs
+++ b/serialization_derive/src/ser.rs
@@ -1,0 +1,59 @@
+use {syn, quote};
+
+pub fn impl_raw_serialize(ast: &syn::DeriveInput) -> quote::Tokens {
+	let body = match ast.body {
+		syn::Body::Struct(ref s) => s,
+		_ => panic!("#[derive(RawSerialize)] is only defined for structs."),
+	};
+
+	let stmts: Vec<_> = match *body {
+		syn::VariantData::Struct(ref fields) => fields.iter().enumerate().map(serialize_field_map).collect(),
+		syn::VariantData::Tuple(ref fields) => fields.iter().enumerate().map(serialize_field_map).collect(),
+		syn::VariantData::Unit => panic!("#[derive(RawSerialize)] is not defined for Unit structs."),
+	};
+
+	let name = &ast.ident;
+
+	let dummy_const = syn::Ident::new(format!("_IMPL_RAW_SERIALIZE_FOR_{}", name));
+	let impl_block = quote! {
+		impl serialization::Serializable for #name {
+			fn serialize(&self, stream: &mut serialization::Stream) {
+				#(#stmts)*
+			}
+		}
+	};
+
+	quote! {
+		#[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+		const #dummy_const: () = {
+			extern crate serialization;
+			#impl_block
+		};
+	}
+}
+
+fn serialize_field_map(tuple: (usize, &syn::Field)) -> quote::Tokens {
+	serialize_field(tuple.0, tuple.1)
+}
+
+fn serialize_field(index: usize, field: &syn::Field) -> quote::Tokens {
+	let ident = match field.ident {
+		Some(ref ident) => ident.to_string(),
+		None => index.to_string(),
+	};
+
+	let id = syn::Ident::new(format!("self.{}", ident));
+
+	match field.ty {
+		syn::Ty::Array(_, _) => quote! { stream.append_list(&#id); },
+		syn::Ty::Slice(_) => quote! { stream.append_list(#id); },
+		syn::Ty::Path(_, ref path) => {
+			let ident = &path.segments.first().expect("there must be at least 1 segment").ident;
+			match &ident.to_string() as &str {
+				"Vec" => quote! { stream.append_list(&#id); },
+				_ => quote! { stream.append(&#id); },
+			}
+		},
+		_ => quote! { stream.append(&#id); },
+	}
+}

--- a/serialization_derive/tests/raw.rs
+++ b/serialization_derive/tests/raw.rs
@@ -1,0 +1,83 @@
+extern crate serialization;
+#[macro_use]
+extern crate serialization_derive;
+
+use serialization::{serialize, deserialize};
+
+#[derive(Debug, PartialEq, RawSerialize, RawDeserialize)]
+struct Foo {
+	a: u8,
+	b: u16,
+	c: u32,
+	d: u64,
+}
+
+#[derive(Debug, PartialEq, RawSerialize, RawDeserialize)]
+struct Bar {
+	a: Vec<Foo>,
+}
+
+#[test]
+fn test_foo_serialize() {
+	let foo = Foo {
+		a: 1,
+		b: 2,
+		c: 3,
+		d: 4,
+	};
+
+	let expected = vec![
+		1u8,
+		2, 0,
+		3, 0, 0, 0,
+		4, 0, 0, 0, 0, 0, 0, 0,
+	].into();
+
+	let result = serialize(&foo);
+	assert_eq!(result, expected);
+
+	let d = deserialize(expected.as_ref()).unwrap();
+	assert_eq!(foo, d);
+}
+
+#[test]
+fn test_bar_serialize() {
+	let foo = Foo {
+		a: 1,
+		b: 2,
+		c: 3,
+		d: 4,
+	};
+
+	let foo2 = Foo {
+		a: 5,
+		b: 6,
+		c: 7,
+		d: 8,
+	};
+
+	let expected = vec![
+		// number of items
+		2u8,
+		// first
+		1,
+		2, 0,
+		3, 0, 0, 0,
+		4, 0, 0, 0, 0, 0, 0, 0,
+		// second
+		5,
+		6, 0,
+		7, 0, 0, 0,
+		8, 0, 0, 0, 0, 0, 0, 0,
+	].into();
+
+	let bar = Bar {
+		a: vec![foo, foo2],
+	};
+
+	let result = serialize(&bar);
+	assert_eq!(result, expected);
+
+	let d = deserialize(expected.as_ref()).unwrap();
+	assert_eq!(bar, d);
+}

--- a/serialization_derive/tests/raw.rs
+++ b/serialization_derive/tests/raw.rs
@@ -4,7 +4,7 @@ extern crate serialization_derive;
 
 use serialization::{serialize, deserialize};
 
-#[derive(Debug, PartialEq, RawSerialize, RawDeserialize)]
+#[derive(Debug, PartialEq, Serializable, Deserializable)]
 struct Foo {
 	a: u8,
 	b: u16,
@@ -12,7 +12,7 @@ struct Foo {
 	d: u64,
 }
 
-#[derive(Debug, PartialEq, RawSerialize, RawDeserialize)]
+#[derive(Debug, PartialEq, Serializable, Deserializable)]
 struct Bar {
 	a: Vec<Foo>,
 }

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -15,6 +15,7 @@ cargo test\
 	-p rpc\
 	-p script\
 	-p serialization\
+	-p serialization_derive\
 	-p sync\
 	-p test-data\
 	-p verification


### PR DESCRIPTION
I was a bit annoyed with the amount of boilerplate we are writing for serialization so I implemented `serialization_derive` here as a poc. If this pr gets accepted, I will do the same for parity's rlp serialization.