### PR TITLE
Synchronization fixes

### DIFF
--- a/message/src/types/version.rs
+++ b/message/src/types/version.rs
@@ -100,6 +100,14 @@ impl Version {
 			Version::V70001(_, _, ref v) => v.relay,
 		}
 	}
+
+	pub fn user_agent(&self) -> Option<String> {
+		match *self {
+			Version::V0(_) => None,
+			Version::V106(_, ref v) |
+			Version::V70001(_, ref v, _) => Some(v.user_agent.clone()),
+		}
+	}
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/p2p/src/net/connections.rs
+++ b/p2p/src/net/connections.rs
@@ -53,6 +53,7 @@ impl Connections {
 		let peer_info = PeerInfo {
 			id: id,
 			address: connection.address,
+			user_agent: connection.version_message.user_agent().unwrap_or("unknown".into()),
 			direction: direction,
 			version: connection.version,
 			version_message: connection.version_message,

--- a/p2p/src/p2p.rs
+++ b/p2p/src/p2p.rs
@@ -89,6 +89,12 @@ impl Context {
 		self.node_table.write().insert_many(nodes);
 	}
 
+	/// Penalize node.
+	pub fn penalize_node(&self, addr: &SocketAddr) {
+		trace!("Penalizing node {}", addr);
+		self.node_table.write().note_failure(addr);
+	}
+
 	/// Adds node to table.
 	pub fn add_node(&self, addr: SocketAddr) -> Result<(), NodeTableError> {
 		trace!("Adding node {} to node table", &addr);

--- a/p2p/src/util/peer.rs
+++ b/p2p/src/util/peer.rs
@@ -14,6 +14,7 @@ pub enum Direction {
 pub struct PeerInfo {
 	pub id: PeerId,
 	pub address: SocketAddr,
+	pub user_agent: String,
 	pub direction: Direction,
 	pub version: u32,
 	pub version_message: types::Version,

--- a/sync/src/inbound_connection.rs
+++ b/sync/src/inbound_connection.rs
@@ -31,8 +31,8 @@ impl InboundConnection {
 }
 
 impl InboundSyncConnection for InboundConnection {
-	fn start_sync_session(&self, version: types::Version) {
-		self.node.on_connect(self.peer_index, version);
+	fn start_sync_session(&self, peer_name: String, version: types::Version) {
+		self.node.on_connect(self.peer_index, peer_name, version);
 	}
 
 	fn close_session(&self) {

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -65,8 +65,8 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 	}
 
 	/// When new peer connects to the node
-	pub fn on_connect(&self, peer_index: PeerIndex, version: types::Version) {
-		trace!(target: "sync", "Starting new sync session with peer#{}", peer_index);
+	pub fn on_connect(&self, peer_index: PeerIndex, peer_name: String, version: types::Version) {
+		trace!(target: "sync", "Starting new sync session with peer#{}: {}", peer_index, peer_name);
 
 		// light clients may not want transactions broadcasting until filter for connection is set
 		if !version.relay_transactions() {
@@ -389,7 +389,7 @@ pub mod tests {
 	#[test]
 	fn local_node_serves_block() {
 		let (_, server, local_node) = create_local_node(None);
-		let peer_index = 0; local_node.on_connect(peer_index, types::Version::default());
+		let peer_index = 0; local_node.on_connect(peer_index, "test".into(), types::Version::default());
 		// peer requests genesis block
 		let genesis_block_hash = test_data::genesis().hash();
 		let inventory = vec![
@@ -411,7 +411,7 @@ pub mod tests {
 		let (executor, _, local_node) = create_local_node(None);
 
 		// transaction will be relayed to this peer
-		let peer_index1 = 0; local_node.on_connect(peer_index1, types::Version::default());
+		let peer_index1 = 0; local_node.on_connect(peer_index1, "test".into(), types::Version::default());
 		executor.take_tasks();
 
 		let genesis = test_data::genesis();
@@ -436,7 +436,7 @@ pub mod tests {
 
 		let (executor, _, local_node) = create_local_node(Some(verifier));
 
-		let peer_index1 = 0; local_node.on_connect(peer_index1, types::Version::default());
+		let peer_index1 = 0; local_node.on_connect(peer_index1, "test".into(), types::Version::default());
 		executor.take_tasks();
 
 		let result = local_node.accept_transaction(transaction);

--- a/sync/src/synchronization_chain.rs
+++ b/sync/src/synchronization_chain.rs
@@ -681,7 +681,7 @@ impl db::BlockHeaderProvider for Chain {
 
 impl fmt::Debug for Information {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "[sch:{} / bh:{} -> req:{} -> vfy:{} -> stored: {}]", self.scheduled, self.headers.best, self.requested, self.verifying, self.stored)
+		write!(f, "[sch:{} -> req:{} -> vfy:{} -> stored: {}]", self.scheduled, self.requested, self.verifying, self.stored)
 	}
 }
 

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use futures::Future;
 use parking_lot::Mutex;
 use time;
+use time::precise_time_s;
 use chain::{IndexedBlockHeader, IndexedTransaction, Transaction, IndexedBlock};
 use message::types;
 use message::common::{InventoryType, InventoryVector};
@@ -19,7 +20,6 @@ use synchronization_peers_tasks::PeersTasks;
 use synchronization_verifier::{VerificationSink, BlockVerificationSink, TransactionVerificationSink, VerificationTask};
 use types::{BlockHeight, ClientCoreRef, PeersRef, PeerIndex, SynchronizationStateRef, EmptyBoxFuture, SyncListenerRef};
 use utils::{AverageSpeedMeter, MessageBlockHeadersProvider, OrphanBlocksPool, OrphanTransactionsPool, HashPosition};
-#[cfg(test)] use synchronization_peers::Peers;
 #[cfg(test)] use synchronization_peers_tasks::{Information as PeersTasksInformation};
 #[cfg(test)] use synchronization_chain::{Information as ChainInformation};
 
@@ -41,6 +41,12 @@ const NEAR_EMPTY_VERIFICATION_QUEUE_THRESHOLD_S: f64 = 20_f64;
 const SYNC_SPEED_BLOCKS_TO_INSPECT: usize = 512;
 /// Number of blocks to inspect when calculating average blocks speed
 const BLOCKS_SPEED_BLOCKS_TO_INSPECT: usize = 512;
+/// Minimal time between duplicated blocks requests.
+const MIN_BLOCK_DUPLICATION_INTERVAL_S: f64 = 10_f64;
+/// Maximal number of blocks in duplicate requests.
+const MAX_BLOCKS_IN_DUPLICATE_REQUEST: BlockHeight = 4;
+/// Minimal number of blocks in duplicate requests.
+const MIN_BLOCKS_IN_DUPLICATE_REQUEST: BlockHeight = 8;
 
 /// Information on current synchronization state.
 #[cfg(test)]
@@ -123,6 +129,8 @@ pub struct SynchronizationClientCore<T: TaskExecutor> {
 	config: Config,
 	/// Synchronization events listener
 	listener: Option<SyncListenerRef>,
+	/// Time of last duplicated blocks request.
+	last_dup_time: f64,
 }
 
 /// Verification sink for synchronization client core
@@ -140,6 +148,20 @@ pub enum State {
 	NearlySaturated,
 	/// We have downloaded all blocks of the blockchain of which we have ever heard
 	Saturated,
+}
+
+/// Blocks request limits.
+pub struct BlocksRequestLimits {
+	/// Approximate maximal number of blocks hashes in scheduled queue.
+	pub max_scheduled_hashes: BlockHeight,
+	/// Approximate maximal number of blocks hashes in requested queue.
+	pub max_requested_blocks: BlockHeight,
+	/// Approximate maximal number of blocks in verifying queue.
+	pub max_verifying_blocks: BlockHeight,
+	/// Minimum number of blocks to request from peer
+	pub min_blocks_in_request: BlockHeight,
+	/// Maximum number of blocks to request from peer
+	pub max_blocks_in_request: BlockHeight,
 }
 
 /// Transaction append error
@@ -189,6 +211,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		self.executor.execute(Task::GetHeaders(peer_index, types::GetHeaders::with_block_locator_hashes(block_locator_hashes)));
 		// unuseful until respond with headers message
 		self.peers_tasks.unuseful_peer(peer_index);
+		self.peers_tasks.on_headers_requested(peer_index);
 	}
 
 	fn on_disconnect(&mut self, peer_index: PeerIndex) {
@@ -467,6 +490,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 			// for now, let's exclude peer from synchronization - we are relying on full nodes for synchronization
 			let removed_tasks = self.peers_tasks.reset_blocks_tasks(peer_index);
 			self.peers_tasks.unuseful_peer(peer_index);
+			self.peers.misbehaving(peer_index, &format!("Responded with NotFound(unrequested_block)"));
 
 			// if peer has had some blocks tasks, rerequest these blocks
 			self.execute_synchronization_tasks(Some(removed_tasks), None);
@@ -516,6 +540,10 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		// display information if processed many blocks || enough time has passed since sync start
 		self.print_synchronization_information();
 
+		// prepare limits
+		let verifying_hashes_len = self.chain.length_of_blocks_state(BlockState::Verifying);
+		let limits = BlocksRequestLimits::default(); // TODO: must be updated using retrieval && verification speed
+
 		// if some blocks requests are forced => we should ask peers even if there are no idle peers
 		if let Some(forced_blocks_requests) = forced_blocks_requests {
 			let useful_peers = self.peers_tasks.useful_peers();
@@ -526,7 +554,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 				return;
 			}
 
-			let forced_tasks = self.prepare_blocks_requests_tasks(useful_peers, forced_blocks_requests);
+			let forced_tasks = self.prepare_blocks_requests_tasks(&limits, useful_peers, forced_blocks_requests);
 			tasks.extend(forced_tasks);
 		}
 
@@ -534,7 +562,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		if let Some(final_blocks_requests) = final_blocks_requests {
 			let useful_peers = self.peers_tasks.useful_peers();
 			if !useful_peers.is_empty() { // if empty => not a problem, just forget these blocks
-				let forced_tasks = self.prepare_blocks_requests_tasks(useful_peers, final_blocks_requests);
+				let forced_tasks = self.prepare_blocks_requests_tasks(&limits, useful_peers, final_blocks_requests);
 				tasks.extend(forced_tasks);
 			}
 		}
@@ -575,7 +603,6 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 				//    => we could ask idle peer2 about [B1, B2, B3, B4]
 				// these requests has priority over new blocks requests below
 				let requested_hashes_len = self.chain.length_of_blocks_state(BlockState::Requested);
-				let verifying_hashes_len = self.chain.length_of_blocks_state(BlockState::Verifying);
 				if requested_hashes_len != 0 {
 					let verification_speed: f64 = self.block_speed_meter.speed();
 					let synchronization_speed: f64 = self.sync_speed_meter.speed();
@@ -609,15 +636,19 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 					// if verification queue will be empty before all synchronization requests will be completed
 					// + do not spam with duplicated blocks requests if blocks are too big && there are still blocks left for NEAR_EMPTY_VERIFICATION_QUEUE_THRESHOLD_S
 					// => duplicate blocks requests
+					let now = precise_time_s();
 					if synchronization_queue_will_be_full_in > verification_queue_will_be_empty_in &&
-						verification_queue_will_be_empty_in < NEAR_EMPTY_VERIFICATION_QUEUE_THRESHOLD_S {
+						verification_queue_will_be_empty_in < NEAR_EMPTY_VERIFICATION_QUEUE_THRESHOLD_S &&
+						now - self.last_dup_time > MIN_BLOCK_DUPLICATION_INTERVAL_S {
+						// do not duplicate too often
+						self.last_dup_time = now;
 						// blocks / second * second -> blocks
-						let hashes_requests_to_duplicate_len = synchronization_speed * (synchronization_queue_will_be_full_in - verification_queue_will_be_empty_in);
+						let hashes_requests_to_duplicate_len = (synchronization_speed * (synchronization_queue_will_be_full_in - verification_queue_will_be_empty_in)) as BlockHeight;
 						// do not ask for too many blocks
-						let hashes_requests_to_duplicate_len = min(MAX_BLOCKS_IN_REQUEST, hashes_requests_to_duplicate_len as BlockHeight);
+						let hashes_requests_to_duplicate_len = min(MAX_BLOCKS_IN_DUPLICATE_REQUEST, hashes_requests_to_duplicate_len);
 						// ask for at least 1 block
-						let hashes_requests_to_duplicate_len = max(1, min(requested_hashes_len, hashes_requests_to_duplicate_len));
-						blocks_requests = Some(self.chain.best_n_of_blocks_state(BlockState::Requested, hashes_requests_to_duplicate_len));
+						let hashes_requests_to_duplicate_len = max(MIN_BLOCKS_IN_DUPLICATE_REQUEST, min(requested_hashes_len, hashes_requests_to_duplicate_len));
+						blocks_requests = Some(self.chain.best_n_of_blocks_state(BlockState::Requested, hashes_requests_to_duplicate_len as BlockHeight));
 
 						trace!(target: "sync", "Duplicating {} blocks requests. Sync speed: {} * {}, blocks speed: {} * {}.", hashes_requests_to_duplicate_len, synchronization_speed, requested_hashes_len, verification_speed, verifying_hashes_len);
 					}
@@ -625,9 +656,10 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 
 				// check if we can move some blocks from scheduled to requested queue
 				{
+					// TODO: only request minimal number of blocks, if other urgent blocks are requested
 					let scheduled_hashes_len = self.chain.length_of_blocks_state(BlockState::Scheduled);
 					if requested_hashes_len + verifying_hashes_len < MAX_REQUESTED_BLOCKS + MAX_VERIFYING_BLOCKS && scheduled_hashes_len != 0 {
-						let chunk_size = min(MAX_BLOCKS_IN_REQUEST, max(scheduled_hashes_len / blocks_idle_peers_len, MIN_BLOCKS_IN_REQUEST));
+						let chunk_size = min(limits.max_blocks_in_request, max(scheduled_hashes_len / blocks_idle_peers_len, limits.min_blocks_in_request));
 						let hashes_to_request_len = chunk_size * blocks_idle_peers_len;
 						let hashes_to_request = self.chain.request_blocks_hashes(hashes_to_request_len);
 						match blocks_requests {
@@ -641,7 +673,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 
 		// append blocks requests tasks
 		if let Some(blocks_requests) = blocks_requests {
-			tasks.extend(self.prepare_blocks_requests_tasks(blocks_idle_peers, blocks_requests));
+			tasks.extend(self.prepare_blocks_requests_tasks(&limits, blocks_idle_peers, blocks_requests));
 		}
 
 		// execute synchronization tasks
@@ -724,6 +756,7 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 				sync_speed_meter: AverageSpeedMeter::with_inspect_items(BLOCKS_SPEED_BLOCKS_TO_INSPECT),
 				config: config,
 				listener: None,
+				last_dup_time: 0f64,
 			}
 		));
 
@@ -758,6 +791,11 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 		&mut self.chain
 	}
 
+	/// Return peers reference
+	pub fn peers(&self) -> PeersRef {
+		self.peers.clone()
+	}
+
 	/// Return peers tasks reference
 	pub fn peers_tasks(&mut self) -> &mut PeersTasks {
 		&mut self.peers_tasks
@@ -779,12 +817,6 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 		self.verify_headers = verify;
 	}
 
-	/// Return peers reference
-	#[cfg(test)]
-	pub fn peers(&mut self) -> &Peers {
-		&*self.peers
-	}
-
 	/// Print synchronization information
 	pub fn print_synchronization_information(&mut self) {
 		if let State::Synchronizing(timestamp, num_of_blocks) = self.state {
@@ -796,9 +828,10 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 				self.state = State::Synchronizing(time::precise_time_s(), new_num_of_blocks);
 
 				use time;
-				info!(target: "sync", "{:?} @ Processed {} blocks in {} seconds. Chain information: {:?}"
+				info!(target: "sync", "{:?} Processed {} blocks in {:.2} seconds. Peers: {:?}. Chain: {:?}"
 					, time::strftime("%H:%M:%S", &time::now()).unwrap()
 					, blocks_diff, timestamp_diff
+					, self.peers_tasks.information()
 					, self.chain.information());
 			}
 		}
@@ -904,13 +937,13 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 		Ok(transactions)
 	}
 
-	fn prepare_blocks_requests_tasks(&mut self, mut peers: Vec<PeerIndex>, mut hashes: Vec<H256>) -> Vec<Task> {
+	fn prepare_blocks_requests_tasks(&mut self, limits: &BlocksRequestLimits, mut peers: Vec<PeerIndex>, mut hashes: Vec<H256>) -> Vec<Task> {
 		use std::mem::swap;
 
 		// ask fastest peers for hashes at the beginning of `hashes`
 		self.peers_tasks.sort_peers_for_blocks(&mut peers);
 
-		let chunk_size = min(MAX_BLOCKS_IN_REQUEST, max(hashes.len() as BlockHeight, MIN_BLOCKS_IN_REQUEST));
+		let chunk_size = min(limits.max_blocks_in_request, max(hashes.len() as BlockHeight, limits.min_blocks_in_request));
 		let last_peer_index = peers.len() - 1;
 		let mut tasks: Vec<Task> = Vec::new();
 		for (peer_index, peer) in peers.into_iter().enumerate() {
@@ -1168,6 +1201,18 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 				}
 			}
 			block_entry.remove_entry();
+		}
+	}
+}
+
+impl Default for BlocksRequestLimits {
+	fn default() -> Self {
+		BlocksRequestLimits {
+			max_scheduled_hashes: MAX_SCHEDULED_HASHES,
+			max_requested_blocks: MAX_REQUESTED_BLOCKS,
+			max_verifying_blocks: MAX_VERIFYING_BLOCKS,
+			min_blocks_in_request: MIN_BLOCKS_IN_REQUEST,
+			max_blocks_in_request: MAX_BLOCKS_IN_REQUEST,
 		}
 	}
 }

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -490,7 +490,9 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 			// for now, let's exclude peer from synchronization - we are relying on full nodes for synchronization
 			let removed_tasks = self.peers_tasks.reset_blocks_tasks(peer_index);
 			self.peers_tasks.unuseful_peer(peer_index);
-			self.peers.misbehaving(peer_index, &format!("Responded with NotFound(unrequested_block)"));
+			if self.state.is_synchronizing() {
+				self.peers.misbehaving(peer_index, &format!("Responded with NotFound(unrequested_block)"));
+			}
 
 			// if peer has had some blocks tasks, rerequest these blocks
 			self.execute_synchronization_tasks(Some(removed_tasks), None);

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -540,11 +540,15 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		// display information if processed many blocks || enough time has passed since sync start
 		self.print_synchronization_information();
 
-		// prepare limits
-		let verifying_hashes_len = self.chain.length_of_blocks_state(BlockState::Verifying);
-		let limits = BlocksRequestLimits::default(); // TODO: must be updated using retrieval && verification speed
+		// prepare limits. TODO: must be updated using current retrieval && verification speed && blocks size
+		let mut limits = BlocksRequestLimits::default();
+		if self.chain.length_of_blocks_state(BlockState::Stored) > 150_000 {
+			limits.min_blocks_in_request = 8;
+			limits.max_blocks_in_request = 16;
+		}
 
 		// if some blocks requests are forced => we should ask peers even if there are no idle peers
+		let verifying_hashes_len = self.chain.length_of_blocks_state(BlockState::Verifying);
 		if let Some(forced_blocks_requests) = forced_blocks_requests {
 			let useful_peers = self.peers_tasks.useful_peers();
 			// if we have to request blocks && there are no useful peers at all => switch to saturated state

--- a/sync/src/synchronization_peers_tasks.rs
+++ b/sync/src/synchronization_peers_tasks.rs
@@ -229,6 +229,7 @@ impl PeersTasks {
 		self.stats.get_mut(&peer_index).map(|br| br.speed.stop());
 
 		// mark this peer as idle for blocks request
+		self.blocks_requests.remove(&peer_index);
 		self.idle_for_blocks.insert(peer_index);
 		// also mark as available for headers request if not yet
 		if !self.headers_requests.contains_key(&peer_index) {

--- a/sync/src/synchronization_peers_tasks.rs
+++ b/sync/src/synchronization_peers_tasks.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use linked_hash_map::LinkedHashMap;
@@ -7,15 +8,13 @@ use types::PeerIndex;
 use utils::AverageSpeedMeter;
 
 /// Max peer failures # before excluding from sync process
-const MAX_PEER_FAILURES: usize = 2;
+const MAX_PEER_FAILURES: usize = 4;
 /// Max blocks failures # before forgetiing this block and restarting sync
 const MAX_BLOCKS_FAILURES: usize = 6;
 /// Number of blocks to inspect while calculating average response time
 const BLOCKS_TO_INSPECT: usize = 32;
 
 /// Information on synchronization peers
-#[cfg(test)]
-#[derive(Debug)]
 pub struct Information {
 	/// # of peers that are marked as useful for current synchronization session && have no pending requests.
 	pub idle: usize,
@@ -62,13 +61,24 @@ pub struct BlocksRequest {
 	pub blocks: HashSet<H256>,
 }
 
+/// Peer trust level.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum TrustLevel {
+	/// Suspicios peer (either it is fresh peer, or it has failed to respond to last requests).
+	Suspicious,
+	/// This peer is responding to requests.
+	Trusted,
+}
+
 /// Peer statistics
-#[derive(Debug, Default)]
-struct PeerStats {
+#[derive(Debug)]
+pub struct PeerStats {
 	/// Number of blocks requests failures
 	failures: usize,
 	/// Average block response time meter
 	speed: AverageSpeedMeter,
+	/// Peer trust level.
+	trust: TrustLevel,
 }
 
 /// Block statistics
@@ -80,7 +90,6 @@ struct BlockStats {
 
 impl PeersTasks {
 	/// Get information on synchronization peers
-	#[cfg(test)]
 	pub fn information(&self) -> Information {
 		let active_for_headers: HashSet<_> = self.headers_requests.keys().cloned().collect();
 		Information {
@@ -135,6 +144,11 @@ impl PeersTasks {
 		self.blocks_requests
 			.get(&peer_index)
 			.map(|br| &br.blocks)
+	}
+
+	/// Get peer statistics
+	pub fn get_peer_stats(&self, peer_index: PeerIndex) -> Option<&PeerStats> {
+		self.stats.get(&peer_index)
 	}
 
 	/// Mark peer as useful.
@@ -194,7 +208,11 @@ impl PeersTasks {
 		};
 
 		// it was requested block => update block response time
-		self.stats.get_mut(&peer_index).map(|br| br.speed.checkpoint());
+		self.stats.get_mut(&peer_index)
+			.map(|br| {
+				br.trust = TrustLevel::Trusted;
+				br.speed.checkpoint()
+			});
 
 		// if it hasn't been last requested block => just return
 		if !is_last_requested_block_received {
@@ -286,10 +304,17 @@ impl PeersTasks {
 	}
 
 	/// We have failed to get headers from peer during given period
-	pub fn on_peer_headers_failure(&mut self, peer_index: PeerIndex) {
+	pub fn on_peer_headers_failure(&mut self, peer_index: PeerIndex) -> bool {
 		// we never penalize peers for header requests failures
 		self.headers_requests.remove(&peer_index);
 		self.idle_for_headers.insert(peer_index);
+
+		self.stats.get_mut(&peer_index)
+			.map(|s| {
+				s.failures += 1;
+				s.failures > MAX_PEER_FAILURES
+			})
+			.unwrap_or_default()
 	}
 
 	/// Reset all peers state to the unuseful
@@ -333,7 +358,18 @@ impl PeerStats {
 		PeerStats {
 			failures: 0,
 			speed: AverageSpeedMeter::with_inspect_items(BLOCKS_TO_INSPECT),
+			trust: TrustLevel::Suspicious,
 		}
+	}
+
+	pub fn trust(&self) -> TrustLevel {
+		self.trust
+	}
+}
+
+impl fmt::Debug for Information {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "[active:{}, idle:{}, bad:{}]", self.active, self.idle, self.unuseful)
 	}
 }
 


### PR DESCRIPTION
closes #399 
closes #375 
closes (partially) #298

1) until now, if peer had many sync failures, it was 'excluded' from synchronization, but still occupied connection slot. Now if it has enough failures, connection is closed + peer is penalized on p2p level (i.e. in NodeTable) to not to reconnect to the same peer right after dropping connection. Without it, pbtc won't survive in post-HF network - it could stay connected to peers from 'other' network forever
2) added stub for dynamic calculation (`BlocksRequestLimits` + `TrustLevel`) of min/max blocks in getdata requests. Large min/max are useful at the beginning of blockchain, when blocks are small. Small are useful after block size increases. Currently I haven't found good equation to calculate this (experimented earlier this week) - so there are still hardcoded values (min1/max1 for blocks < 150_000 and min2/max2 for blocks > 150_000). Left TODO in code to fix this
3) fixed issue with peer penalizing (I suppose this was the main reason behind #399 )
4) decreased number of blocks duplicating requests && number of blocks in these requests - still dumb, but works smoothly (this is #375 && #298 )
5) peer is now penalized even if has failed to respond to headers request (i.e. peer which is in initial blockchain synchronization state won't occupy connection slot, if we are also in this state)
5) improved sync logging (log peer IP && client when sync starts) + slightly changed informant (still could be more informative - will add more important info later)