### PR TITLE
`rollback` command implemented

### DIFF
--- a/db/src/block_chain.rs
+++ b/db/src/block_chain.rs
@@ -15,6 +15,9 @@ pub trait BlockChain {
 	/// Inserts new block into blockchain
 	fn insert(&self, block: IndexedBlock) -> Result<(), Error>;
 
+	/// Rollbacks single best block. Returns new best block hash
+	fn rollback_best(&self) -> Result<H256, Error>;
+
 	/// Canonizes block with given hash
 	fn canonize(&self, block_hash: &H256) -> Result<(), Error>;
 

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -101,3 +101,9 @@ subcommands:
             - PATH:
                 required: true
                 help: Path of the bitcoin core database
+    - rollback:
+        about: Rollback database to given canon-chain block
+        args:
+            - BLOCK:
+                required: true
+                help: Either block hash, or block number 

--- a/pbtc/commands/mod.rs
+++ b/pbtc/commands/mod.rs
@@ -1,5 +1,7 @@
 mod import;
 mod start;
+mod rollback;
 
 pub use self::import::import;
 pub use self::start::start;
+pub use self::rollback::rollback;

--- a/pbtc/commands/rollback.rs
+++ b/pbtc/commands/rollback.rs
@@ -1,0 +1,39 @@
+use clap::ArgMatches;
+use db::BlockRef;
+use config::Config;
+use primitives::hash::H256;
+use util::{open_db, init_db};
+
+pub fn rollback(cfg: Config, matches: &ArgMatches) -> Result<(), String> {
+	let db = open_db(&cfg);
+	try!(init_db(&cfg, &db));
+
+	let block_ref = matches.value_of("BLOCK").expect("BLOCK is required in cli.yml; qed");
+	let block_ref = if block_ref.len() == 64 {
+		BlockRef::Hash({
+			let hash: H256 = block_ref.parse().map_err(|e| format!("Invalid block number: {}", e))?;
+			hash.reversed()
+		})
+	} else {
+		BlockRef::Number(block_ref.parse().map_err(|e| format!("Invalid block hash: {}", e))?)
+	};
+
+	let required_block_hash = db.block_header(block_ref.clone()).ok_or(format!("Block {:?} is unknown", block_ref))?.hash();
+	let genesis_hash = cfg.magic.genesis_block().hash();
+
+	let mut best_block_hash = db.best_block().hash;
+	debug_assert!(best_block_hash != H256::default()); // genesis inserted in init_db
+
+	loop {
+		if best_block_hash == required_block_hash {
+			info!("Reverted to block {:?}", block_ref);
+			return Ok(());
+		} 
+
+		if best_block_hash == genesis_hash {
+			return Err(format!("Failed to revert to block {:?}. Reverted to genesis", block_ref));
+		}
+
+		best_block_hash = db.rollback_best().map_err(|e| format!("{:?}", e))?;
+	}
+}

--- a/pbtc/main.rs
+++ b/pbtc/main.rs
@@ -64,6 +64,7 @@ fn run() -> Result<(), String> {
 
 	match matches.subcommand() {
 		("import", Some(import_matches)) => commands::import(cfg, import_matches),
+		("rollback", Some(rollback_matches)) => commands::rollback(cfg, rollback_matches),
 		_ => commands::start(cfg),
 	}
 }


### PR DESCRIPTION
closes #437

Example:
```
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1000
Block Number(1000) is unknown
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ RUST_LOG=sync=info ./pbtc --db-cache=2048 -d ./db.test 2>&1 | tee start_trace.log
INFO:sync::synchronization_client_core: Processed 1000 blocks in 1.04 seconds (965.40 blk/s).	Peers: 9 (act: 9, idl: 0, bad: 4).	Chain: [sch:4336 -> req:517 -> vfy:147 -> stored: 1001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.58 seconds (1713.47 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 2).	Chain: [sch:3184 -> req:797 -> vfy:19 -> stored: 2001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.88 seconds (1137.90 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 2).	Chain: [sch:3520 -> req:1024 -> vfy:456 -> stored: 3001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.61 seconds (1648.46 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 2).	Chain: [sch:4880 -> req:1118 -> vfy:2 -> stored: 4001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.39 seconds (2546.44 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 2).	Chain: [sch:3984 -> req:896 -> vfy:120 -> stored: 5001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.78 seconds (1283.11 blk/s).	Peers: 10 (act: 9, idl: 1, bad: 2).	Chain: [sch:5088 -> req:870 -> vfy:42 -> stored: 6001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.78 seconds (1285.32 blk/s).	Peers: 10 (act: 2, idl: 8, bad: 2).	Chain: [sch:4320 -> req:0 -> vfy:680 -> stored: 7001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.50 seconds (1987.30 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 2).	Chain: [sch:3296 -> req:704 -> vfy:0 -> stored: 8001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.74 seconds (1355.60 blk/s).	Peers: 10 (act: 3, idl: 7, bad: 2).	Chain: [sch:4400 -> req:384 -> vfy:216 -> stored: 9001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 1.02 seconds (979.98 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 1).	Chain: [sch:4352 -> req:1152 -> vfy:496 -> stored: 10001]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.54 seconds (1835.58 blk/s).	Peers: 10 (act: 2, idl: 8, bad: 1).	Chain: [sch:4352 -> req:128 -> vfy:520 -> stored: 11001]
^C
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1000
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1000
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1001
Block Number(1001) is unknown
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 999
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1000
Block Number(1000) is unknown
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ RUST_LOG=sync=info ./pbtc --db-cache=2048 -d ./db.test 2>&1 | tee start_trace.log
INFO:sync::synchronization_client_core: Processed 1000 blocks in 3.10 seconds (322.84 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 1).	Chain: [sch:4080 -> req:920 -> vfy:0 -> stored: 2000]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 14.42 seconds (69.36 blk/s).	Peers: 10 (act: 1, idl: 9, bad: 0).	Chain: [sch:5184 -> req:0 -> vfy:816 -> stored: 3000]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.44 seconds (2285.00 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 0).	Chain: [sch:3904 -> req:1096 -> vfy:0 -> stored: 4000]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 11.24 seconds (88.94 blk/s).	Peers: 10 (act: 0, idl: 10, bad: 0).	Chain: [sch:5008 -> req:0 -> vfy:992 -> stored: 5000]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.24 seconds (4148.85 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 0).	Chain: [sch:3728 -> req:1271 -> vfy:1 -> stored: 6000]
INFO:sync::synchronization_client_core: Processed 1000 blocks in 0.59 seconds (1687.17 blk/s).	Peers: 10 (act: 10, idl: 0, bad: 0).	Chain: [sch:4832 -> req:1168 -> vfy:0 -> stored: 7000]
^C
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1001
Block Number(1001) is unknown
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc --db-cache=2048 -d ./db.test 2>&1 rollback 1000
```