### PR TITLE
Default to default logging sync=info

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,37 +171,42 @@ Full list of cli options, which is available under `pbtc --help`
 
 ```
 pbtc 0.1.0
-Parity Technologies <admin@parity.io>
-Parity bitcoin client
+Parity Technologies <info@parity.io>
+Parity Bitcoin client
 
 USAGE:
     pbtc [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
+        --bitcoin-cash        Use Bitcoin Cash verification rules.
     -h, --help                Prints help information
-        --no-jsonrpc          Disable the JSON-RPC API server
-        --print-to-console    Send sync info to console
-        --regtest             Use private network for regtest
-        --testnet             Use the test network
+        --no-jsonrpc          Disable the JSON-RPC API server.
+        --print-to-console    Show synchronization information in your console.
+        --regtest             Use a private network for regression tests.
+        --segwit2x            Enable SegWit2x verification rules.
+        --testnet             Use the test network (Testnet3).
     -V, --version             Prints version information
 
 OPTIONS:
-        --blocknotify <command>            Execute command when the best block changes (%s in cmd is replaced by block hash)
-    -c, --connect <IP>                     Connect only to the specified node
-    -d, --data-dir <PATH>                  Specify the database & configuration directory PATH
-        --db-cache <SIZE>                  Sets db cache size
-        --jsonrpc-apis <APIS>              Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API name.
-        --jsonrpc-cors <URL>               Specify CORS header for JSON-RPC API responses
-        --jsonrpc-hosts <HOSTS>            List of allowed Host header values
-        --jsonrpc-interface <INTERFACE>    The hostname portion of the JSONRPC API server
-        --jsonrpc-port <PORT>              The port portion of the JSONRPC API server
-        --only-net <NET>                   Only connect to nodes in network <NET> (ipv4 or ipv6)
-        --port <PORT>                      Listen for connections on PORT
-    -s, --seednode <IP>                    Connect to a node to retrieve peer addresses, and disconnect
+        --blocknotify <command>            Execute command when the best block changes (%s in cmd is replaced by the block hash).
+    -c, --connect <IP>                     Connect only to the specified node.
+    -d, --data-dir <PATH>                  Specify the database and configuration directory PATH.
+        --db-cache <SIZE>                  Sets the database cache size.
+        --jsonrpc-apis <APIS>              Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API names.
+        --jsonrpc-cors <URL>               Specify CORS header for JSON-RPC API responses.
+        --jsonrpc-hosts <HOSTS>            List of allowed Host header values.
+        --jsonrpc-interface <INTERFACE>    The hostname portion of the JSONRPC API server.
+        --jsonrpc-port <PORT>              Specify the PORT for the JSONRPC API server.
+        --only-net <NET>                   Only connect to nodes in network version <NET> (ipv4 or ipv6).
+        --port <PORT>                      Listen for connections on PORT.
+    -s, --seednode <IP>                    Connect to a seed-node to retrieve peer addresses, and disconnect.
+        --verification-edge <BLOCK>        Non-default verification-level is applied until a block with given hash is met.
+        --verification-level <LEVEL>       Sets the Blocks verification level to full (default), header (scripts are not verified), or none (no verification at all).
 
 SUBCOMMANDS:
-    help      Prints this message or the help of the given subcommand(s)
-    import    Import blocks from bitcoin core database
+    help        Prints this message or the help of the given subcommand(s)
+    import      Import blocks from a Bitcoin Core database.
+    rollback    Rollback the database to given canonical-chain block.
 ```
 
 ## JSON-RPC

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ FLAGS:
     -V, --version             Prints version information
 
 OPTIONS:
-        --blocknotify <command>            Execute command when the best block changes (%s in cmd is replaced by the block hash).
+        --blocknotify <COMMAND>            Execute COMMAND when the best block changes (%s in cmd is replaced by the block hash).
     -c, --connect <IP>                     Connect only to the specified node.
     -d, --data-dir <PATH>                  Specify the database and configuration directory PATH.
         --db-cache <SIZE>                  Sets the database cache size.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# parity-bitcoin
-The Parity Bitcoin client
+# The Parity Bitcoin client.
 
 [![Build Status][travis-image]][travis-url] [![Snap Status](https://build.snapcraft.io/badge/paritytech/parity-bitcoin.svg)](https://build.snapcraft.io/user/paritytech/parity-bitcoin)
 
@@ -38,7 +37,7 @@ Minimal supported version is `rustc 1.16.0 (30cf806ef 2017-03-10)`
 
 #### Install rustc and cargo
 
-Both `rustc` and `cargo` are a part of rust toolchain.
+Both `rustc` and `cargo` are a part of rust tool-chain.
 
 An easy way to install the stable binaries for Linux and Mac is to run this in your shell:
 
@@ -94,7 +93,7 @@ sudo snap install parity-bitcoin --edge
 
 #### Running unit tests
 
-Assuming that repo is already cloned, we can run unit tests with this command:
+Assuming that repository is already cloned, we can run unit tests with this command:
 
 ```
 ./tools/test.sh
@@ -102,7 +101,7 @@ Assuming that repo is already cloned, we can run unit tests with this command:
 
 #### Running external integration tests
 
-Running integration tests is automated, as regtests repo is one of the submodules. Let's download it first:
+Running integration tests is automated, as the regtests repository is one of the submodules. Let's download it first:
 
 ```
 git submodule update --init
@@ -130,9 +129,9 @@ java -jar pull-tests-f56eec3.jar
 
 ## Going online
 
-By default parity connects to bitcoind seednodes. Full list is [here](./pbtc/seednodes.rs).
+By default parity connects to bitcoind-seednodes. Full list is [here](./pbtc/seednodes.rs).
 
-To start syncing the mainnet, just start the client:
+To start syncing the main network, just start the client:
 
 ```
 ./target/release/pbtc
@@ -152,7 +151,7 @@ To not print any syncing progress add `--quiet` flag:
 
 ## Importing bitcoind database
 
-It it is possible to import existing bitcoind database:
+It it is possible to import existing `bitcoind` database:
 
 ```
 # where $BITCOIND_DB is path to your bitcoind database, e.g., "/Users/user/Library/Application Support"
@@ -215,15 +214,15 @@ TODO
 
 ## Logging
 
-This is a section only for dev / power users.
+This is a section only for developers and power users.
 
-You can enable detailed client logging by setting env variable `RUST_LOG`, e.g.,
+You can enable detailed client logging by setting the environment variable `RUST_LOG`, e.g.,
 
 ```
 RUST_LOG=verification=info ./target/release/pbtc --quiet
 ```
 
-`pbtc` started with this env variable will print all logs comming from `verification` module with verbosity `info` or higher. Available log levels are:
+`pbtc` started with this environment variable will print all logs coming from `verification` module with verbosity `info` or higher. Available log levels are:
 
 - `error`
 - `warn`
@@ -237,7 +236,7 @@ It's also possible to start logging from multiple modules in the same time:
 RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --quiet
 ```
 
-**Note:** `RUST_LOG` does only work together with command line option `--quiet` which will surpress the default `sync=info` logging.
+**Note:** `RUST_LOG` does only work together with command line option `--quiet` which will suppress the default `sync=info` logging.
 
 ## Internal documentation
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ It it is possible to import existing `bitcoind` database:
 ./target/release/pbtc import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
-By default import verifies imported the blocks. You can disable this, by adding `--skip-verification flag.
+By default import verifies imported the blocks. You can disable this, by adding `--skip-verification` flag.
 
 ```
 ./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --skip-verification
@@ -336,7 +336,7 @@ This is a section only for developers and power users.
 You can enable detailed client logging by setting the environment variable `RUST_LOG`, e.g.,
 
 ```
-RUST_LOG=verification=info ./target/release/pbtc --quiet
+RUST_LOG=verification=info ./target/release/pbtc
 ```
 
 `pbtc` started with this environment variable will print all logs coming from `verification` module with verbosity `info` or higher. Available log levels are:
@@ -350,10 +350,8 @@ RUST_LOG=verification=info ./target/release/pbtc --quiet
 It's also possible to start logging from multiple modules in the same time:
 
 ```
-RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --quiet
+RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc
 ```
-
-**Note:** `RUST_LOG` does only work together with command line option `--quiet` which will suppress the default `sync=info` logging.
 
 ## Internal documentation
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Windows binaries can be downloaded from [rust-lang website](https://www.rust-lan
 
 #### Install C and C++ compilers
 
-You will need the cc and gcc compilers to build some of the dependencies
+You will need the cc and gcc compilers to build some of the dependencies.
 
 ```
 sudo apt-get update
@@ -59,14 +59,14 @@ sudo apt-get install build-essential
 
 #### Clone and build pbtc
 
-Now let's clone `pbtc` and enter it's directory
+Now let's clone `pbtc` and enter it's directory:
 
 ```
 git clone https://github.com/paritytech/parity-bitcoin
 cd parity-bitcoin
 ```
 
-`pbtc` can be build in two modes. `--debug` and `--release`. Debug is the default
+`pbtc` can be build in two modes. `--debug` and `--release`. Debug is the default.
 
 ```
 # builds pbtc in debug mode
@@ -78,7 +78,7 @@ cargo build -p pbtc
 cargo build -p pbtc --release
 ```
 
-`pbtc` is now available at either `./target/debug/pbtc` or `./target/release/pbtc`
+`pbtc` is now available at either `./target/debug/pbtc` or `./target/release/pbtc`.
 
 ## Installing the snap
 
@@ -90,7 +90,7 @@ sudo snap install parity-bitcoin --edge
 
 ## Running tests
 
-`pbtc` has internal unit tests and it conforms to external integration tests
+`pbtc` has internal unit tests and it conforms to external integration tests.
 
 #### Running unit tests
 
@@ -108,13 +108,13 @@ Running integration tests is automated, as regtests repo is one of the submodule
 git submodule update --init
 ```
 
-Now we can run them
+Now we can run them:
 
 ```
 ./tools/regtests.sh
 ```
 
-It's also possible to run regtests manually
+It's also possible to run regtests manually:
 
 ```
 # let's start pbtc in regtest compatible mode
@@ -130,24 +130,24 @@ java -jar pull-tests-f56eec3.jar
 
 ## Going online
 
-By default parity connects to bitcoind seednodes. Full list is [here](./pbtc/seednodes.rs)
+By default parity connects to bitcoind seednodes. Full list is [here](./pbtc/seednodes.rs).
 
-To start syncing the mainnet, just start the client
+To start syncing the mainnet, just start the client:
 
 ```
 ./target/release/pbtc
 ```
 
-To start syncing the testnet
+To start syncing the testnet:
 
 ```
 ./target/release/pbtc --testnet
 ```
 
-To print syncing progress add `--print-to-console` flag
+To not print any syncing progress add `--quiet` flag:
 
 ```
-./target/release/pbtc --print-to-console
+./target/release/pbtc --quiet
 ```
 
 ## Importing bitcoind database
@@ -155,19 +155,19 @@ To print syncing progress add `--print-to-console` flag
 It it is possible to import existing bitcoind database:
 
 ```
-# where $BITCOIND_DB is path to your bitcoind database eg. "/Users/marek/Library/Application Support"
-./target/release/pbtc --print-to-console import "$BITCOIND_DB/Bitcoin/blocks"
+# where $BITCOIND_DB is path to your bitcoind database, e.g., "/Users/user/Library/Application Support"
+./target/release/pbtc import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
 By default import verifies imported the blocks. You can disable this, by adding `--skip-verification flag.
 
 ```
-./target/release/pbtc --print-to-console import "#BITCOIND_DB/Bitcoin/blocks" --skip-verification
+./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --skip-verification
 ```
 
 ## Command line interface
 
-Full list of cli options, which is available under `pbtc --help`
+Full list of CLI options, which is available under `pbtc --help`:
 
 ```
 pbtc 0.1.0
@@ -178,17 +178,17 @@ USAGE:
     pbtc [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
-        --bitcoin-cash        Use Bitcoin Cash verification rules.
-    -h, --help                Prints help information
-        --no-jsonrpc          Disable the JSON-RPC API server.
-        --print-to-console    Show synchronization information in your console.
-        --regtest             Use a private network for regression tests.
-        --segwit2x            Enable SegWit2x verification rules.
-        --testnet             Use the test network (Testnet3).
-    -V, --version             Prints version information
+        --bitcoin-cash    Use Bitcoin Cash verification rules.
+    -h, --help            Prints help information
+        --no-jsonrpc      Disable the JSON-RPC API server.
+    -q, --quiet           Do not show any synchronization information in the console.
+        --regtest         Use a private network for regression tests.
+        --segwit2x        Enable SegWit2x verification rules.
+        --testnet         Use the test network (Testnet3).
+    -V, --version         Prints version information
 
 OPTIONS:
-        --blocknotify <COMMAND>            Execute COMMAND when the best block changes (%s in cmd is replaced by the block hash).
+        --blocknotify <COMMAND>            Execute COMMAND when the best block changes (%s in COMMAND is replaced by the block hash).
     -c, --connect <IP>                     Connect only to the specified node.
     -d, --data-dir <PATH>                  Specify the database and configuration directory PATH.
         --db-cache <SIZE>                  Sets the database cache size.
@@ -217,17 +217,13 @@ TODO
 
 This is a section only for dev / power users.
 
-You can enable detailed client logging by setting env variable `RUST_LOG`
-
-eg.
+You can enable detailed client logging by setting env variable `RUST_LOG`, e.g.,
 
 ```
-RUST_LOG=verification=info ./target/release/pbtc
+RUST_LOG=verification=info ./target/release/pbtc --quiet
 ```
 
-`pbtc` started with this env variable will print all logs comming from `verification` module with verbosity `info` or higher
-
-Available log levels:
+`pbtc` started with this env variable will print all logs comming from `verification` module with verbosity `info` or higher. Available log levels are:
 
 - `error`
 - `warn`
@@ -235,13 +231,13 @@ Available log levels:
 - `debug`
 - `trace`
 
-It's also possible to start logging from multiple modules in the same time
+It's also possible to start logging from multiple modules in the same time:
 
 ```
-RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace
+RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --quiet
 ```
 
-*note* `RUST_LOG` does not work together with command line option `--print-to-console`
+**Note:** `RUST_LOG` does only work together with command line option `--quiet` which will surpress the default `sync=info` logging.
 
 ## Internal documentation
 

--- a/logs/src/lib.rs
+++ b/logs/src/lib.rs
@@ -3,6 +3,7 @@ extern crate log;
 extern crate env_logger;
 extern crate time;
 
+use std::env;
 use ansi_term::Colour as Color;
 use log::{LogRecord, LogLevel};
 use env_logger::LogBuilder;
@@ -46,7 +47,12 @@ impl LogFormatter for DateAndColorLogFormatter {
 
 pub fn init<T>(filters: &str, formatter: T) where T: LogFormatter {
 	let mut builder = LogBuilder::new();
-	builder.parse(filters);
+	let filters = match env::var("RUST_LOG") {
+		Ok(env_filters) => format!("{},{}", env_filters, filters),
+		Err(_) => filters.into(),
+	};
+
+	builder.parse(&filters);
 	builder.format(move |record| formatter.format(record));
 	builder.init().expect("Logger can be initialized only once");
 }

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -1,109 +1,109 @@
 name: pbtc
 version: "0.1.0"
-author: Parity Technologies <admin@parity.io>
-about: Parity bitcoin client
+author: Parity Technologies <info@parity.io>
+about: Parity Bitcoin client
 args:
     - testnet:
         long: testnet
-        help: Use the test network
+        help: Use the test network (Testnet3).
     - regtest:
         long: regtest
-        help: Use private network for regtest
+        help: Use a private network for regression tests.
     - segwit2x:
         long: segwit2x
-        help: Enable SegWit2x verification rules
+        help: Enable SegWit2x verification rules.
     - bitcoin-cash:
         long: bitcoin-cash
-        help: Use Bitcoin Cash verification rules
+        help: Use Bitcoin Cash verification rules.
     - connect:
         short: c
         long: connect
         value_name: IP
-        help: Connect only to the specified node
+        help: Connect only to the specified node.
         takes_value: true
     - seednode:
         short: s
         long: seednode
         value_name: IP
-        help: Connect to a node to retrieve peer addresses, and disconnect
+        help: Connect to a seed-node to retrieve peer addresses, and disconnect.
         takes_value: true
     - port:
         long: port
         value_name: PORT
-        help: Listen for connections on PORT
+        help: Listen for connections on PORT.
         takes_value: true
     - print-to-console:
         long: print-to-console
-        help: Send sync info to console
+        help: Show synchronization information in your console.
     - data-dir:
         short: d
         long: data-dir
         value_name: PATH
-        help: Specify the database & configuration directory PATH
+        help: Specify the database and configuration directory PATH.
         takes_value: true
     - db-cache:
         long: db-cache
         value_name: SIZE
-        help: Sets db cache size
+        help: Sets the database cache size.
         takes_value: true
     - only-net:
         long: only-net
         value_name: NET
-        help: Only connect to nodes in network <NET> (ipv4 or ipv6)
+        help: Only connect to nodes in network version <NET> (ipv4 or ipv6).
         takes_value: true
     - no-jsonrpc:
         long: no-jsonrpc
-        help: Disable the JSON-RPC API server
+        help: Disable the JSON-RPC API server.
     - jsonrpc-port:
         long: jsonrpc-port
-        help: The port portion of the JSONRPC API server
+        help: Specify the PORT for the JSONRPC API server.
         takes_value: true
         value_name: PORT
     - jsonrpc-interface:
         long: jsonrpc-interface
-        help: The hostname portion of the JSONRPC API server
+        help: The hostname portion of the JSONRPC API server.
         takes_value: true
         value_name: INTERFACE
     - jsonrpc-cors:
         long: jsonrpc-cors
-        help: Specify CORS header for JSON-RPC API responses
+        help: Specify CORS header for JSON-RPC API responses.
         takes_value: true
         value_name: URL
     - jsonrpc-apis:
         long: jsonrpc-apis
-        help: Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API name.
+        help: Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API names.
         takes_value: true
         value_name: APIS
     - jsonrpc-hosts:
         long: jsonrpc-hosts
-        help: List of allowed Host header values
+        help: List of allowed Host header values.
         takes_value: true
         value_name: HOSTS
     - blocknotify:
         long: blocknotify
-        help: Execute command when the best block changes (%s in cmd is replaced by block hash)
+        help: Execute command when the best block changes (%s in cmd is replaced by the block hash).
         takes_value: true
         value_name: command
     - verification-level:
         long: verification-level
-        help: Blocks verification level - full (default), header (scripts are not verified), none (no verification at all)
+        help: Sets the Blocks verification level to full (default), header (scripts are not verified), or none (no verification at all).
         takes_value: true
         value_name: LEVEL
     - verification-edge:
         long: verification-edge
-        help: Non-default verification-level is applied until block with given hash is met.
+        help: Non-default verification-level is applied until a block with given hash is met.
         takes_value: true
         value_name: BLOCK
 subcommands:
     - import:
-        about: Import blocks from bitcoin core database
+        about: Import blocks from a Bitcoin Core database.
         args:
             - PATH:
                 required: true
-                help: Path of the bitcoin core database
+                help: Path of the Bitcoin Core database.
     - rollback:
-        about: Rollback database to given canon-chain block
+        about: Rollback the database to given canonical-chain block.
         args:
             - BLOCK:
                 required: true
-                help: Either block hash, or block number 
+                help: Either block hash, or block number.

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -32,9 +32,10 @@ args:
         value_name: PORT
         help: Listen for connections on PORT.
         takes_value: true
-    - print-to-console:
-        long: print-to-console
-        help: Show synchronization information in your console.
+    - quiet:
+        short: q
+        long: quiet
+        help: Do not show any synchronization information in the console.
     - data-dir:
         short: d
         long: data-dir

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -72,7 +72,7 @@ args:
         value_name: URL
     - jsonrpc-apis:
         long: jsonrpc-apis
-        help: Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API name. Available APIs are blockchain, network, miner, raw.
+        help: Specify the APIs available through the JSONRPC interface. APIS is a comma-delimited list of API names. Available APIs are blockchain, network, miner, raw.
         takes_value: true
         value_name: APIS
     - jsonrpc-hosts:

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -81,9 +81,9 @@ args:
         value_name: HOSTS
     - blocknotify:
         long: blocknotify
-        help: Execute command when the best block changes (%s in cmd is replaced by the block hash).
+        help: Execute COMMAND when the best block changes (%s in COMMAND is replaced by the block hash).
         takes_value: true
-        value_name: command
+        value_name: COMMAND
     - verification-level:
         long: verification-level
         help: Sets the Blocks verification level to full (default), header (scripts are not verified), or none (no verification at all).

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
 	pub port: u16,
 	pub connect: Option<net::SocketAddr>,
 	pub seednodes: Vec<String>,
-	pub print_to_console: bool,
+	pub quiet: bool,
 	pub inbound_connections: u32,
 	pub outbound_connections: u32,
 	pub p2p_threads: usize,
@@ -34,7 +34,7 @@ pub struct Config {
 pub const DEFAULT_DB_CACHE: usize = 512;
 
 pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
-	let print_to_console = matches.is_present("print-to-console");
+	let quiet = matches.is_present("quiet");
 	let magic = match (matches.is_present("testnet"), matches.is_present("regtest")) {
 		(true, false) => Magic::Testnet,
 		(false, true) => Magic::Regtest,
@@ -139,7 +139,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 	};
 
 	let config = Config {
-		print_to_console: print_to_console,
+		quiet: quiet,
 		magic: magic,
 		consensus: consensus,
 		services: services,

--- a/pbtc/main.rs
+++ b/pbtc/main.rs
@@ -52,7 +52,7 @@ fn run() -> Result<(), String> {
 	let matches = clap::App::from_yaml(yaml).get_matches();
 	let cfg = try!(config::parse(&matches));
 
-	if cfg.print_to_console {
+	if !cfg.quiet {
 		if cfg!(windows) {
 			logs::init(LOG_INFO, logs::DateLogFormatter);
 		} else {


### PR DESCRIPTION
Incldues:

- Default to default logging `sync=info`.
- Introduce `--quiet` flag to suppress that.
- Improve help messages wording a little bit.
- Updated README.md to reflect the changes.

Rationale:

- It certainly makes sense to default to `sync=info` logging at some point. (Or to write a beautiful logger.)
- Downside is that any use of `RUST_LOG` only works in combination with the `-q` switch to suppress the default logging.