### PR TITLE
Added deployments tests from bitcoin

### DIFF
--- a/db/src/block_ancestors.rs
+++ b/db/src/block_ancestors.rs
@@ -2,14 +2,14 @@ use chain::BlockHeader;
 use {BlockRef, BlockHeaderProvider};
 
 pub struct BlockAncestors<'a> {
-	block: BlockRef,
+	block: Option<BlockRef>,
 	headers: &'a BlockHeaderProvider,
 }
 
 impl<'a> BlockAncestors<'a> {
 	pub fn new(block: BlockRef, headers: &'a BlockHeaderProvider) -> Self {
 		BlockAncestors {
-			block: block,
+			block: Some(block),
 			headers: headers,
 		}
 	}
@@ -19,10 +19,11 @@ impl<'a> Iterator for BlockAncestors<'a> {
 	type Item = BlockHeader;
 
 	fn next(&mut self) -> Option<Self::Item> {
-		let result = self.headers.block_header(self.block.clone());
-		if let Some(ref header) = result {
-			self.block = BlockRef::Hash(header.previous_header_hash.clone());
-		}
+		let result = self.block.take().and_then(|block| self.headers.block_header(block));
+		self.block = match result {
+			Some(ref header) => Some(BlockRef::Hash(header.previous_header_hash.clone())),
+			None => None,
+		};
 		result
 	}
 }

--- a/verification/src/accept_header.rs
+++ b/verification/src/accept_header.rs
@@ -54,8 +54,8 @@ impl<'a> HeaderVersion<'a> {
 
 	fn check(&self) -> Result<(), Error> {
 		if (self.header.raw.version < 2 && self.height >= self.consensus_params.bip34_height) ||
-			(self.header.raw.version < 3 && self.height >= self.consensus_params.bip65_height) ||
-			(self.header.raw.version < 4 && self.height >= self.consensus_params.bip66_height) {
+			(self.header.raw.version < 3 && self.height >= self.consensus_params.bip66_height) ||
+			(self.header.raw.version < 4 && self.height >= self.consensus_params.bip65_height) {
 			Err(Error::OldVersionBlock)
 		} else {
 			Ok(())


### PR DESCRIPTION
+ fixed deployments calculation

It is a part of #443 fix - I'll return `expect()` call after synchronizing testnet