### PR TITLE
Force user to select chain on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It's also possible to run regtests manually:
 
 ```
 # let's start pbtc in regtest compatible mode
-./target/release/pbtc --regtest
+./target/release/pbtc --segwit --regtest
 
 # now in second shell window
 cd $HOME
@@ -131,22 +131,24 @@ java -jar pull-tests-f56eec3.jar
 
 By default parity connects to bitcoind-seednodes. Full list is [here](./pbtc/seednodes.rs).
 
-To start syncing the main network, just start the client:
+Before starting synchronization, you must decide - which fork to follow - SegWit (`--segwit` flag), SegWit2x (`--segwit2x` flag) or Bitcoin Cash (`--bitcoin-cash` flag). On next start, passing the same flag is optional, as the database is already bound to selected fork and won't be synchronized using other verification rules.
+
+To start syncing the main network, just start the client, passing selected fork flag. For example:
 
 ```
-./target/release/pbtc
+./target/release/pbtc --segwit
 ```
 
 To start syncing the testnet:
 
 ```
-./target/release/pbtc --testnet
+./target/release/pbtc --segwit --testnet
 ```
 
 To not print any syncing progress add `--quiet` flag:
 
 ```
-./target/release/pbtc --quiet
+./target/release/pbtc --segwit --quiet
 ```
 
 ## Importing bitcoind database
@@ -158,10 +160,10 @@ It it is possible to import existing `bitcoind` database:
 ./target/release/pbtc import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
-By default import verifies imported the blocks. You can disable this, by adding `--skip-verification` flag.
+By default import verifies imported the blocks. You can disable this, by adding `--verification-level==none` flag.
 
 ```
-./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --skip-verification
+./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --segwit --skip-verification
 ```
 
 ## Command line interface
@@ -182,6 +184,7 @@ FLAGS:
         --no-jsonrpc      Disable the JSON-RPC API server.
     -q, --quiet           Do not show any synchronization information in the console.
         --regtest         Use a private network for regression tests.
+        --segwit          Enable SegWit verification rules.
         --segwit2x        Enable SegWit2x verification rules.
         --testnet         Use the test network (Testnet3).
     -V, --version         Prints version information
@@ -336,7 +339,7 @@ This is a section only for developers and power users.
 You can enable detailed client logging by setting the environment variable `RUST_LOG`, e.g.,
 
 ```
-RUST_LOG=verification=info ./target/release/pbtc
+RUST_LOG=verification=info ./target/release/pbtc --segwit
 ```
 
 `pbtc` started with this environment variable will print all logs coming from `verification` module with verbosity `info` or higher. Available log levels are:
@@ -350,7 +353,7 @@ RUST_LOG=verification=info ./target/release/pbtc
 It's also possible to start logging from multiple modules in the same time:
 
 ```
-RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc
+RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --segwit
 ```
 
 ## Internal documentation

--- a/db/src/block_chain_db.rs
+++ b/db/src/block_chain_db.rs
@@ -23,7 +23,7 @@ use best_block::BestBlock;
 use {
 	BlockRef, Error, BlockHeaderProvider, BlockProvider, BlockOrigin, TransactionMeta, IndexedBlockProvider,
 	TransactionMetaProvider, TransactionProvider, TransactionOutputProvider, BlockChain, Store,
-	SideChainOrigin, ForkChain, Forkable, CanonStore
+	SideChainOrigin, ForkChain, Forkable, CanonStore, ConfigStore
 };
 
 const KEY_BEST_BLOCK_NUMBER: &'static str = "best_block_number";
@@ -565,5 +565,25 @@ impl<T> Store for BlockChainDatabase<T> where T: KeyValueDatabase {
 	/// get blockchain difficulty
 	fn difficulty(&self) -> f64 {
 		self.best_header().bits.to_f64()
+	}
+}
+
+impl<T> ConfigStore for BlockChainDatabase<T> where T: KeyValueDatabase {
+	fn consensus_fork(&self) -> Result<Option<String>, Error> {
+		match self.db.get(&Key::Configuration("consensus_fork"))
+			.map(KeyState::into_option)
+			.map(|x| x.and_then(Value::as_configuration)) {
+			Ok(Some(consensus_fork)) => String::from_utf8(consensus_fork.into())
+				.map_err(|e| Error::DatabaseError(format!("{}", e)))
+				.map(Some),
+			Ok(None) => Ok(None),
+			Err(e) => Err(Error::DatabaseError(e.into())),
+		}
+	}
+
+	fn set_consensus_fork(&self, consensus_fork: &str) -> Result<(), Error> {
+		let mut update = DBTransaction::new();
+		update.insert(KeyValue::Configuration("consensus_fork", consensus_fork.as_bytes().into()));
+		self.db.write(update).map_err(Error::DatabaseError)
 	}
 }

--- a/db/src/error.rs
+++ b/db/src/error.rs
@@ -9,3 +9,14 @@ pub enum Error {
 	/// Ancient fork
 	AncientFork,
 }
+
+impl Into<String> for Error {
+	fn into(self) -> String {
+		match self {
+			Error::DatabaseError(s) => format!("Database error: {}", s),
+			Error::CannotCanonize => "Cannot canonize block".into(),
+			Error::UnknownParent => "Block parent is unknown".into(),
+			Error::AncientFork => "Fork is too long to proceed".into(),
+		}
+	}
+}

--- a/db/src/error.rs
+++ b/db/src/error.rs
@@ -10,9 +10,9 @@ pub enum Error {
 	AncientFork,
 }
 
-impl Into<String> for Error {
-	fn into(self) -> String {
-		match self {
+impl From<Error> for String {
+	fn from(e: Error) -> String {
+		match e {
 			Error::DatabaseError(s) => format!("Database error: {}", s),
 			Error::CannotCanonize => "Cannot canonize block".into(),
 			Error::UnknownParent => "Block parent is unknown".into(),

--- a/db/src/kv/transaction.rs
+++ b/db/src/kv/transaction.rs
@@ -12,6 +12,7 @@ pub const COL_BLOCK_TRANSACTIONS: u32 = 3;
 pub const COL_TRANSACTIONS: u32 = 4;
 pub const COL_TRANSACTIONS_META: u32 = 5;
 pub const COL_BLOCK_NUMBERS: u32 = 6;
+pub const COL_CONFIGURATION: u32 = 7;
 
 #[derive(Debug)]
 pub enum Operation {
@@ -28,6 +29,7 @@ pub enum KeyValue {
 	Transaction(H256, ChainTransaction),
 	TransactionMeta(H256, TransactionMeta),
 	BlockNumber(H256, u32),
+	Configuration(&'static str, Bytes),
 }
 
 #[derive(Debug)]
@@ -39,6 +41,7 @@ pub enum Key {
 	Transaction(H256),
 	TransactionMeta(H256),
 	BlockNumber(H256),
+	Configuration(&'static str),
 }
 
 #[derive(Debug, Clone)]
@@ -50,6 +53,7 @@ pub enum Value {
 	Transaction(ChainTransaction),
 	TransactionMeta(TransactionMeta),
 	BlockNumber(u32),
+	Configuration(Bytes),
 }
 
 impl Value {
@@ -62,6 +66,7 @@ impl Value {
 			Key::Transaction(_) => deserialize(bytes).map(Value::Transaction),
 			Key::TransactionMeta(_) => deserialize(bytes).map(Value::TransactionMeta),
 			Key::BlockNumber(_) => deserialize(bytes).map(Value::BlockNumber),
+			Key::Configuration(_) => deserialize(bytes).map(Value::Configuration),
 		}.map_err(|e| format!("{:?}", e))
 	}
 
@@ -110,6 +115,13 @@ impl Value {
 	pub fn as_block_number(self) -> Option<u32> {
 		match self {
 			Value::BlockNumber(number) => Some(number),
+			_ => None,
+		}
+	}
+
+	pub fn as_configuration(self) -> Option<Bytes> {
+		match self {
+			Value::Configuration(bytes) => Some(bytes),
 			_ => None,
 		}
 	}
@@ -215,6 +227,7 @@ impl<'a> From<&'a KeyValue> for RawKeyValue {
 			KeyValue::Transaction(ref key, ref value) => (COL_TRANSACTIONS, serialize(key), serialize(value)),
 			KeyValue::TransactionMeta(ref key, ref value) => (COL_TRANSACTIONS_META, serialize(key), serialize(value)),
 			KeyValue::BlockNumber(ref key, ref value) => (COL_BLOCK_NUMBERS, serialize(key), serialize(value)),
+			KeyValue::Configuration(ref key, ref value) => (COL_CONFIGURATION, serialize(key), serialize(value)),
 		};
 
 		RawKeyValue {
@@ -249,6 +262,7 @@ impl<'a> From<&'a Key> for RawKey {
 			Key::Transaction(ref key) => (COL_TRANSACTIONS, serialize(key)),
 			Key::TransactionMeta(ref key) => (COL_TRANSACTIONS_META, serialize(key)),
 			Key::BlockNumber(ref key) => (COL_BLOCK_NUMBERS, serialize(key)),
+			Key::Configuration(ref key) => (COL_CONFIGURATION, serialize(key)),
 		};
 
 		RawKey {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -36,7 +36,7 @@ pub use block_origin::{BlockOrigin, SideChainOrigin};
 pub use block_provider::{BlockHeaderProvider, BlockProvider, IndexedBlockProvider};
 pub use block_ref::BlockRef;
 pub use error::Error;
-pub use store::{AsSubstore, Store, SharedStore, CanonStore};
+pub use store::{AsSubstore, Store, SharedStore, CanonStore, ConfigStore};
 pub use transaction_meta::TransactionMeta;
 pub use transaction_provider::{TransactionProvider, TransactionOutputProvider, TransactionMetaProvider};
 

--- a/db/src/store.rs
+++ b/db/src/store.rs
@@ -2,11 +2,20 @@ use std::sync::Arc;
 use chain::BlockHeader;
 use {
 	BestBlock, BlockProvider, BlockHeaderProvider, TransactionProvider, TransactionMetaProvider,
-	TransactionOutputProvider, BlockChain, IndexedBlockProvider, Forkable
+	TransactionOutputProvider, BlockChain, IndexedBlockProvider, Forkable, Error
 };
 
-pub trait CanonStore: Store + Forkable {
+pub trait CanonStore: Store + Forkable + ConfigStore {
 	fn as_store(&self) -> &Store;
+}
+
+/// Configuration storage interface
+pub trait ConfigStore {
+	/// get consensus_fork this database is configured for
+	fn consensus_fork(&self) -> Result<Option<String>, Error>;
+
+	/// set consensus_fork this database is configured for
+	fn set_consensus_fork(&self, consensus_fork: &str) -> Result<(), Error>;
 }
 
 /// Blockchain storage interface

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -9,6 +9,9 @@ args:
     - regtest:
         long: regtest
         help: Use a private network for regression tests.
+    - segwit:
+        long: segwit
+        help: Enable SegWit verification rules.
     - segwit2x:
         long: segwit2x
         help: Enable SegWit2x verification rules.

--- a/pbtc/commands/import.rs
+++ b/pbtc/commands/import.rs
@@ -1,16 +1,14 @@
 use clap::ArgMatches;
 use sync::{create_sync_blocks_writer, Error};
 use config::Config;
-use util::{open_db, init_db};
+use util::init_db;
 
 pub fn import(cfg: Config, matches: &ArgMatches) -> Result<(), String> {
-	let db = open_db(&cfg);
-	// TODO: this might be unnecessary here!
-	try!(init_db(&cfg, &db));
+	try!(init_db(&cfg));
 
 	let blk_path = matches.value_of("PATH").expect("PATH is required in cli.yml; qed");
 
-	let mut writer = create_sync_blocks_writer(db, cfg.consensus, cfg.verification_params);
+	let mut writer = create_sync_blocks_writer(cfg.db, cfg.consensus, cfg.verification_params);
 
 	let blk_dir = try!(::import::open_blk_dir(blk_path).map_err(|_| "Import directory does not exist".to_owned()));
 	let mut counter = 0;

--- a/pbtc/commands/start.rs
+++ b/pbtc/commands/start.rs
@@ -5,7 +5,7 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 use std::sync::atomic::{AtomicBool, Ordering};
 use sync::{create_sync_peers, create_local_sync_node, create_sync_connection_factory, SyncListener};
 use primitives::hash::H256;
-use util::{open_db, init_db, node_table_path};
+use util::{init_db, node_table_path};
 use {config, p2p, PROTOCOL_VERSION, PROTOCOL_MINIMUM};
 use super::super::rpc;
 
@@ -84,8 +84,7 @@ impl Drop for BlockNotifier {
 pub fn start(cfg: config::Config) -> Result<(), String> {
 	let mut el = p2p::event_loop();
 
-	let db = open_db(&cfg);
-	init_db(&cfg, &db)?;
+	init_db(&cfg)?;
 
 	let nodes_path = node_table_path(&cfg);
 
@@ -111,7 +110,7 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 	};
 
 	let sync_peers = create_sync_peers();
-	let local_sync_node = create_local_sync_node(cfg.consensus, db.clone(), sync_peers.clone(), cfg.verification_params);
+	let local_sync_node = create_local_sync_node(cfg.consensus, cfg.db.clone(), sync_peers.clone(), cfg.verification_params);
 	let sync_connection_factory = create_sync_connection_factory(sync_peers.clone(), local_sync_node.clone());
 
 	if let Some(block_notify_command) = cfg.block_notify_command {
@@ -121,7 +120,7 @@ pub fn start(cfg: config::Config) -> Result<(), String> {
 	let p2p = try!(p2p::P2P::new(p2p_cfg, sync_connection_factory, el.handle()).map_err(|x| x.to_string()));
 	let rpc_deps = rpc::Dependencies {
 		network: cfg.magic,
-		storage: db,
+		storage: cfg.db,
 		local_sync_node: local_sync_node,
 		p2p_context: p2p.context().clone(),
 		remote: el.remote(),

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -1,5 +1,6 @@
 use std::net;
 use clap;
+use db;
 use message::Services;
 use network::{Magic, ConsensusParams, ConsensusFork, SEGWIT2X_FORK_BLOCK, BITCOIN_CASH_FORK_BLOCK};
 use p2p::InternetProtocol;
@@ -10,6 +11,7 @@ use primitives::hash::H256;
 use rpc::HttpConfiguration as RpcHttpConfig;
 use verification::VerificationLevel;
 use sync::VerificationParameters;
+use util::open_db;
 
 pub struct Config {
 	pub magic: Magic,
@@ -29,11 +31,24 @@ pub struct Config {
 	pub rpc_config: RpcHttpConfig,
 	pub block_notify_command: Option<String>,
 	pub verification_params: VerificationParameters,
+	pub db: db::SharedStore,
 }
 
 pub const DEFAULT_DB_CACHE: usize = 512;
 
 pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
+	let db_cache = match matches.value_of("db-cache") {
+		Some(s) => s.parse().map_err(|_| "Invalid cache size - should be number in MB".to_owned())?,
+		None => DEFAULT_DB_CACHE,
+	};
+
+	let data_dir = match matches.value_of("data-dir") {
+		Some(s) => Some(s.parse().map_err(|_| "Invalid data-dir".to_owned())?),
+		None => None,
+	};
+
+	let db = open_db(&data_dir, db_cache);
+
 	let quiet = matches.is_present("quiet");
 	let magic = match (matches.is_present("testnet"), matches.is_present("regtest")) {
 		(true, false) => Magic::Testnet,
@@ -42,12 +57,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		(true, true) => return Err("Only one testnet option can be used".into()),
 	};
 
-	let (consensus_fork, user_agent_suffix) = match (matches.is_present("segwit2x"), matches.is_present("bitcoin-cash")) {
-		(true, false) => (ConsensusFork::SegWit2x(SEGWIT2X_FORK_BLOCK), "/SegWit2x"),
-		(false, true) => (ConsensusFork::BitcoinCash(BITCOIN_CASH_FORK_BLOCK), "/UAHF"),
-		(false, false) => (ConsensusFork::NoFork, ""),
-		(true, true) => return Err("Only one fork can be used".into()),
-	};
+	let consensus_fork = parse_consensus_fork(&db, &matches)?;
 	let consensus = ConsensusParams::new(magic, consensus_fork);
 
 	let (in_connections, out_connections) = match magic {
@@ -61,6 +71,11 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 	};
 
 	// to skip idiotic 30 seconds delay in test-scripts
+	let user_agent_suffix = match consensus_fork {
+		ConsensusFork::NoFork => "",
+		ConsensusFork::SegWit2x(_) => "/SegWit2x",
+		ConsensusFork::BitcoinCash(_) => "/UAHF",
+	};
 	let user_agent = match magic {
 		Magic::Testnet | Magic::Mainnet | Magic::Unitest | Magic::Other(_) => format!("{}{}", USER_AGENT, user_agent_suffix),
 		Magic::Regtest => REGTEST_USER_AGENT.into(),
@@ -93,16 +108,6 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		ConsensusFork::SegWit2x(_) => seednodes.extend(segwit2x_seednodes().into_iter().map(Into::into)),
 		_ => (),
 	}
-
-	let db_cache = match matches.value_of("db-cache") {
-		Some(s) => s.parse().map_err(|_| "Invalid cache size - should be number in MB".to_owned())?,
-		None => DEFAULT_DB_CACHE,
-	};
-
-	let data_dir = match matches.value_of("data-dir") {
-		Some(s) => Some(s.parse().map_err(|_| "Invalid data-dir".to_owned())?),
-		None => None,
-	};
 
 	let only_net = match matches.value_of("only-net") {
 		Some(s) => s.parse()?,
@@ -159,9 +164,41 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 			verification_level: verification_level,
 			verification_edge: verification_edge,
 		},
+		db: db,
 	};
 
 	Ok(config)
+}
+
+fn parse_consensus_fork(db: &db::SharedStore, matches: &clap::ArgMatches) -> Result<ConsensusFork, String> {
+	let old_consensus_fork = match db.consensus_fork() {
+		Ok(consensus_fork) => consensus_fork,
+		Err(err) => return Err(err.into()),
+	};
+	let new_consensus_fork = match (matches.is_present("segwit"), matches.is_present("segwit2x"), matches.is_present("bitcoin-cash")) {
+		(false, false, false) if old_consensus_fork.is_none() =>
+			return Err("You must select fork on first run: --segwit, --segwit2x, --bitcoin-cash".into()),
+		(true, false, false) => "segwit",
+		(false, true, false) => "segwit2x",
+		(false, false, true) => "bitcoin-cash",
+		_ => return Err("You can only pass single fork argument: --segwit, --segwit2x, --bitcoin-cash".into()),
+	};
+
+	match old_consensus_fork {
+		None => match db.set_consensus_fork(new_consensus_fork) {
+			Ok(()) => (),
+			Err(err) => return Err(err.into()),
+		},
+		Some(ref old_consensus_fork) if old_consensus_fork == new_consensus_fork => (),
+		Some(old_consensus_fork) => return Err(format!("Cannnot select '{}' fork with non-empty database of '{}' fork", new_consensus_fork, old_consensus_fork)),
+	}
+
+	Ok(match new_consensus_fork {
+		"segwit" => ConsensusFork::NoFork,
+		"segwit2x" => ConsensusFork::SegWit2x(SEGWIT2X_FORK_BLOCK),
+		"bitcoin-cash" => ConsensusFork::BitcoinCash(BITCOIN_CASH_FORK_BLOCK),
+		_ => unreachable!("hardcoded above"),
+	})
 }
 
 fn parse_rpc_config(magic: Magic, matches: &clap::ArgMatches) -> Result<RpcHttpConfig, String> {

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -171,10 +171,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 }
 
 fn parse_consensus_fork(db: &db::SharedStore, matches: &clap::ArgMatches) -> Result<ConsensusFork, String> {
-	let old_consensus_fork = match db.consensus_fork() {
-		Ok(consensus_fork) => consensus_fork,
-		Err(err) => return Err(err.into()),
-	};
+	let old_consensus_fork = db.consensus_fork()?;
 	let new_consensus_fork = match (matches.is_present("segwit"), matches.is_present("segwit2x"), matches.is_present("bitcoin-cash")) {
 		(false, false, false) => match &old_consensus_fork {
 			&Some(ref old_consensus_fork) => old_consensus_fork,
@@ -187,10 +184,7 @@ fn parse_consensus_fork(db: &db::SharedStore, matches: &clap::ArgMatches) -> Res
 	};
 
 	match &old_consensus_fork {
-		&None => match db.set_consensus_fork(new_consensus_fork) {
-			Ok(()) => (),
-			Err(err) => return Err(err.into()),
-		},
+		&None => db.set_consensus_fork(new_consensus_fork)?,
 		&Some(ref old_consensus_fork) if old_consensus_fork == new_consensus_fork => (),
 		&Some(ref old_consensus_fork) =>
 			return Err(format!("Cannot select '{}' fork with non-empty database of '{}' fork", new_consensus_fork, old_consensus_fork)),

--- a/tools/regtests.sh
+++ b/tools/regtests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./target/release/pbtc --regtest --db-cache=192 &
+./target/release/pbtc --segwit --regtest --db-cache=192 &
 ! java -jar ./tools/compare-tool/pull-tests-be0eef7.jar /tmp/regtest-db 2>&1 | tee regtests-full.log | grep -E --color=auto 'org.bitcoinj.store.BlockStoreException\:|BitcoindComparisonTool.main\: ERROR|bitcoind sent us a block it already had, make sure bitcoind has no blocks!|java.lang.NullPointerException'
 GREP_COLOR="01;32" grep 'BitcoindComparisonTool.main: Block "b1001" completed processing' regtests-full.log
 result=$?


### PR DESCRIPTION
So from now users without database or with empty database or with old version of database will receive message => "You must select fork on first run: --segwit, --segwit2x, --bitcoin-cash".
After selecting fork, it can't be changed anymore. Trying to switch to another fork will lead to "Cannot select 'segwit2x' fork with non-empty database of 'segwit' fork"-like error.
After first run, fork is read from database => passing flag is not required anymore.

Example:
```
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ rm -rf db.test
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc -d db.test
You must select fork on first run: --segwit, --segwit2x, --bitcoin-cash
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc -d db.test --segwit
2017-09-01 17:13:14  INFO sync Processed 1000 blocks in 1.09 seconds (915.16 blk/s).	Peers: 6 (act: 6, idl: 0, bad: 1).	Chain: [sch:4336 -> req:640 -> vfy:24 -> stored: 1001]
2017-09-01 17:13:16  INFO sync Processed 1000 blocks in 1.19 seconds (841.61 blk/s).	Peers: 6 (act: 5, idl: 1, bad: 1).	Chain: [sch:5440 -> req:559 -> vfy:1 -> stored: 2001]
2017-09-01 17:13:17  INFO sync Processed 1000 blocks in 1.38 seconds (722.58 blk/s).	Peers: 6 (act: 6, idl: 0, bad: 0).	Chain: [sch:4160 -> req:815 -> vfy:25 -> stored: 3001]
2017-09-01 17:13:23  INFO sync Processed 1000 blocks in 5.93 seconds (168.67 blk/s).	Peers: 6 (act: 1, idl: 5, bad: 0).	Chain: [sch:5136 -> req:0 -> vfy:864 -> stored: 4001]
2017-09-01 17:13:23  INFO sync Processed 1000 blocks in 0.57 seconds (1747.58 blk/s).	Peers: 7 (act: 2, idl: 5, bad: 1).	Chain: [sch:4368 -> req:256 -> vfy:376 -> stored: 5001]
2017-09-01 17:13:25  INFO sync Processed 1000 blocks in 1.19 seconds (838.31 blk/s).	Peers: 7 (act: 7, idl: 0, bad: 0).	Chain: [sch:4832 -> req:893 -> vfy:275 -> stored: 6001]
2017-09-01 17:13:26  INFO sync Processed 1000 blocks in 1.14 seconds (879.93 blk/s).	Peers: 7 (act: 7, idl: 0, bad: 0).	Chain: [sch:4064 -> req:875 -> vfy:61 -> stored: 7001]
^C
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc -d db.test --segwit2x
Cannot select 'segwit2x' fork with non-empty database of 'segwit' fork
svyatonik@xwnotebook:~/dev/parity-bitcoin.test$ ./pbtc -d db.test
2017-09-01 17:13:46  WARN sync Failed to get requested block from peer#2 in 9.48 seconds.
2017-09-01 17:13:54  INFO sync Processed 1000 blocks in 16.81 seconds (59.50 blk/s).	Peers: 9 (act: 9, idl: 0, bad: 2).	Chain: [sch:3951 -> req:896 -> vfy:153 -> stored: 8074]
2017-09-01 17:13:56  WARN sync Failed to get requested block from peer#2 in 9.82 seconds.
2017-09-01 17:13:57  INFO sync Processed 1000 blocks in 2.98 seconds (336.05 blk/s).	Peers: 9 (act: 9, idl: 0, bad: 1).	Chain: [sch:4927 -> req:1024 -> vfy:49 -> stored: 9074]
2017-09-01 17:14:06  WARN sync Failed to get requested block from peer#10 in 9.73 seconds.
2017-09-01 17:14:06  WARN sync Failed to get requested block from peer#2 in 9.73 seconds.
2017-09-01 17:14:06  WARN sync Too many header failures for peer#2. Excluding from synchronization.
2017-09-01 17:14:06  WARN sync Disconnecting from peer#2 due to misbehavior: Too many header failures.
2017-09-01 17:14:07  INFO sync Processed 1000 blocks in 10.08 seconds (99.25 blk/s).	Peers: 8 (act: 0, idl: 7, bad: 1).	Chain: [sch:4415 -> req:0 -> vfy:585 -> stored: 10074]
2017-09-01 17:14:07  INFO sync Processed 1000 blocks in 0.44 seconds (2271.73 blk/s).	Peers: 8 (act: 8, idl: 0, bad: 1).	Chain: [sch:3135 -> req:733 -> vfy:132 -> stored: 11074]
```