### PR TITLE
Update Dockerfiles to multi-stage and Ubuntu 16.04

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,10 +1,18 @@
-FROM ubuntu:14.04
-MAINTAINER Parity Technologies <devops@parity.io>
-WORKDIR /build
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+
+# Build image
+FROM rust:1.21-jessie AS build
+
 #ENV for build TAG
 ARG BUILD_TAG
-ENV BUILD_TAG ${BUILD_TAG:-master}
+ENV BUILD_TAG=${BUILD_TAG:-master} \
+    PATH=/root/.cargo/bin:$PATH \
+    RUST_BACKTRACE=1
+
+WORKDIR /build
 RUN echo $BUILD_TAG
+
 # install tools and dependencies
 RUN apt-get update && \
         apt-get install -y --force-yes --no-install-recommends \
@@ -17,35 +25,25 @@ RUN apt-get update && \
         ca-certificates \
         libssl-dev \
         pkg-config \
-        libudev-dev && \
-# install rustup
- curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-# rustup directory
- PATH=/root/.cargo/bin:$PATH && \
-# show backtraces
- RUST_BACKTRACE=1 && \
+        libudev-dev
+
 # build pbtc-ubuntu
- cd /build&&git clone https://github.com/paritytech/parity-bitcoin && \
-        cd parity-bitcoin && \
-	git pull&& \
-	git checkout $BUILD_TAG && \
-        cargo build --verbose --release && \
-        strip /build/parity-bitcoin/target/release/pbtc && \
- file /build/parity-bitcoin/target/release/pbtc&&mkdir -p /pbtc-ubuntu&& \
- cp /build/parity-bitcoin/target/release/pbtc /pbtc-ubuntu/pbtc-ubuntu&& \
-#cleanup Docker image
- rm -rf /root/.cargo&&rm -rf /root/.multirust&&rm -rf /root/.rustup&&rm -rf /build&&\
- apt-get purge -y  \
- g++ \
- build-essential \
- curl \
- git \
- file \
- binutils \
- libssl-dev \
- pkg-config \
- libudev-dev && \
- rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/paritytech/parity-bitcoin
+
+WORKDIR /build/parity-bitcoin
+RUN git pull
+RUN git checkout $BUILD_TAG
+RUN cargo build --verbose --release
+RUN strip /build/parity-bitcoin/target/release/pbtc
+RUN file /build/parity-bitcoin/target/release/pbtc
+
+# Runtime image, copies pbtc artifact from build image
+FROM ubuntu:16.04 AS run
+LABEL maintainer "Parity Technologies <devops@parity.io>"
+
+WORKDIR /pbtc-ubuntu
+COPY --from=build /build/parity-bitcoin/target/release/pbtc/ /pbtc-ubuntu/pbtc-ubuntu
+
 # setup ENTRYPOINT
 EXPOSE 8333 18333 8332 18332
 ENTRYPOINT ["/pbtc-ubuntu/pbtc-ubuntu"]

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,39 +1,48 @@
-FROM ubuntu:14.04
-WORKDIR /build
-ADD . /build/pbtc
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+
+### Base Image
+# Setup up a base image to use in Build and Runtime images
+FROM rust:1.21-jessie AS build
+
+# rustup directory
+ENV PATH=/root/.cargo/bin:$PATH \
+    RUST_BACKTRACE=1
+
+WORKDIR /build/parity-bitcoin
+COPY . /build/parity-bitcoin
 
 # install tools and dependencies
 RUN apt-get update && \
-        apt-get install -y \
+        apt-get install -y --force-yes --no-install-recommends \
         g++ \
         build-essential \
         curl \
         git \
         file \
         binutils \
+        ca-certificates \
         libssl-dev \
         pkg-config \
         libudev-dev
 
-# install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# rustup directory
-ENV PATH /root/.cargo/bin:$PATH
-
-# show backtraces
-ENV RUST_BACKTRACE 1
-
 # show tools
-RUN rustc -vV && \
-cargo -V && \
-gcc -v &&\
-g++ -v
+RUN rustc -vV
+RUN cargo -V
+RUN gcc -v
+RUN g++ -v
 
 # build pbtc
-RUN cd pbtc && cargo build --release --verbose
+RUN cargo build --release --verbose
+RUN strip /build/parity-bitcoin/target/release/pbtc
+RUN file /build/parity-bitcoin/target/release/pbtc
 
-RUN file /build/pbtc/target/release/pbtc
+# Runtime image, copies pbtc artifact from build image
+FROM ubuntu:16.04 AS run
+LABEL maintainer "Parity Technologies <devops@parity.io>"
+
+WORKDIR /pbtc-ubuntu
+COPY --from=build /build/parity-bitcoin/target/release/pbtc /pbtc-ubuntu/
 
 EXPOSE 8333 18333 8332 18332
-ENTRYPOINT ["/build/pbtc/target/release/pbtc"]
+ENTRYPOINT ["/pbtc-ubuntu/pbtc"]


### PR DESCRIPTION
Fixes: #409

There are already Dockerfiles present, but this PR updates them to,

- Use a [multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) to improve image size and remove unnecessary packages after build
- Use Ubuntu 16.04 instead of 14.04 for the runtime image

Tested both hub and non-hub builds and `pbtc` binary runs successfully from runtime container.