### PR TITLE
Remove segwit2x mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ java -jar pull-tests-f56eec3.jar
 
 By default parity connects to bitcoind-seednodes. Full list is [here](./pbtc/seednodes.rs).
 
-Before starting synchronization, you must decide - which fork to follow - SegWit (`--segwit` flag), SegWit2x (`--segwit2x` flag) or Bitcoin Cash (`--bitcoin-cash` flag). On next start, passing the same flag is optional, as the database is already bound to selected fork and won't be synchronized using other verification rules.
+Before starting synchronization, you must decide - which fork to follow - SegWit (`--segwit` flag) or Bitcoin Cash (`--bitcoin-cash` flag). On next start, passing the same flag is optional, as the database is already bound to selected fork and won't be synchronized using other verification rules.
 
 To start syncing the main network, just start the client, passing selected fork flag. For example:
 
@@ -185,7 +185,6 @@ FLAGS:
     -q, --quiet           Do not show any synchronization information in the console.
         --regtest         Use a private network for regression tests.
         --segwit          Enable SegWit verification rules.
-        --segwit2x        Enable SegWit2x verification rules.
         --testnet         Use the test network (Testnet3).
     -V, --version         Prints version information
 

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -10,6 +10,6 @@ mod network;
 
 pub use primitives::{hash, compact};
 
-pub use consensus::{ConsensusParams, ConsensusFork, BitcoinCashConsensusParams, SegWit2xConsensusParams};
+pub use consensus::{ConsensusParams, ConsensusFork, BitcoinCashConsensusParams};
 pub use deployments::Deployment;
 pub use network::{Magic, Network};

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -12,9 +12,6 @@ args:
     - segwit:
         long: segwit
         help: Enable SegWit verification rules.
-    - segwit2x:
-        long: segwit2x
-        help: Enable SegWit2x verification rules.
     - bitcoin-cash:
         long: bitcoin-cash
         help: Use Bitcoin Cash verification rules.

--- a/pbtc/seednodes.rs
+++ b/pbtc/seednodes.rs
@@ -41,12 +41,3 @@ pub fn bitcoin_cash_testnet_seednodes() -> Vec<&'static str> {
 		"testnet-seed.bitprim.org:18333",
 	]
 }
-
-pub fn segwit2x_seednodes() -> Vec<&'static str> {
-	vec![
-		"seed.mainnet.b-pay.net:8333",
-		"seed.ob1.io:8333",
-		"seed.blockchain.info:8333",
-		"bitcoin.bloqseeds.net:8333",
-	]
-}

--- a/verification/src/accept_block.rs
+++ b/verification/src/accept_block.rs
@@ -111,7 +111,6 @@ impl<'a> BlockSerializedSize<'a> {
 		// before SegWit: it is main check for size
 		// after SegWit: without witness data, block size should be <= 1_000_000
 		// after BitcoinCash fork: block size is increased to 8_000_000
-		// after SegWit2x fork: without witness data, block size should be <= 2_000_000
 		if size < self.consensus.fork.min_block_size(self.height) ||
 			size > self.consensus.fork.max_block_size(self.height) {
 			return Err(Error::Size(size));
@@ -164,7 +163,6 @@ impl<'a> BlockSigops<'a> {
 		// before SegWit: 20_000
 		// after SegWit: cost of sigops is sigops * 4 and max cost is 80_000 => max sigops is still 20_000
 		// after BitcoinCash fork: 20_000 sigops for each full/partial 1_000_000 bytes of block
-		// after SegWit2x fork: cost of sigops is sigops * 4 and max cost is 160_000 => max sigops is 40_000
 		let size = self.block.size();
 		if sigops > self.consensus.fork.max_block_sigops(self.height, size) {
 			return Err(Error::MaximumSigops);
@@ -174,7 +172,6 @@ impl<'a> BlockSigops<'a> {
 		// before SegWit: no witnesses => cost is sigops * 4 and max cost is 80_000
 		// after SegWit: it is main check for sigops
 		// after BitcoinCash fork: no witnesses => cost is sigops * 4 and max cost depends on block size
-		// after SegWit2x: it is basic check for sigops, limits are increased
 		if sigops_cost > self.consensus.fork.max_block_sigops_cost(self.height, size) {
 			Err(Error::MaximumSigopsCost)
 		} else {

--- a/verification/src/accept_transaction.rs
+++ b/verification/src/accept_transaction.rs
@@ -313,7 +313,7 @@ impl<'a> TransactionEval<'a> {
 		let verify_dersig = height >= params.bip66_height;
 		let signature_version = match params.fork {
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => SignatureVersion::ForkId,
-			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) | ConsensusFork::SegWit2x(_) => SignatureVersion::Base,
+			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => SignatureVersion::Base,
 		};
 
 		let verify_checksequence = deployments.csv();


### PR DESCRIPTION
Since there are now 2 **different** forks named 'Segwit2x':
https://segwit2x.github.io/ - increasing max block size to 2MB
http://b2x-segwit.io - increasing block size, difficulty adjustment, premine, different hashing algorithm, ...

And the origin (1st one) fork has failed => let's remove all mentions for not to confuse users.