### PR TITLE
Fixed BoxFuture-related warnings

### DIFF
--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use parking_lot::{Mutex, Condvar};
 use time;
-use futures::{Future, lazy, finished};
+use futures::{lazy, finished};
 use chain::{Transaction, IndexedTransaction, IndexedBlock};
 use message::types;
 use miner::BlockAssembler;
@@ -163,8 +163,8 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 		let lazy_server_task = lazy(move || {
 			server.upgrade().map(|s| s.execute(server_task));
 			finished::<(), ()>(())
-		}).boxed();
-		self.client.after_peer_nearly_blocks_verified(peer_index, lazy_server_task);
+		});
+		self.client.after_peer_nearly_blocks_verified(peer_index, Box::new(lazy_server_task));
 	}
 
 	/// When peer is requesting for memory pool contents

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use futures::BoxFuture;
+use futures::Future;
 use parking_lot::{Mutex, RwLock};
 use db;
 use local_node::LocalNode;
@@ -21,7 +21,7 @@ pub type RequestId = u32;
 pub type PeerIndex = usize;
 
 // No-error, no-result future
-pub type EmptyBoxFuture = BoxFuture<(), ()>;
+pub type EmptyBoxFuture = Box<Future<Item=(), Error=()> + Send>;
 
 /// Reference to storage
 pub type StorageRef = db::SharedStore;


### PR DESCRIPTION
closes #473 

Was working on some `pbtc` changes && found that some actual warnings are hidden behind these.
Fixed it with a bruteforce - just added `Box::new()` where required.