### PR TITLE
Removed AsciiExt import

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Gitter [![Gitter https://gitter.im/paritytech/parity-bitcoin](https://badges.git
 
 Installing `pbtc` from source requires `rustc` and `cargo`.
 
-Minimal supported version is `rustc 1.16.0 (30cf806ef 2017-03-10)`
+Minimal supported version is `rustc 1.23.0 (766bd11c8 2018-01-01)`
 
 #### Install rustc and cargo
 

--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 
 # Build image
-FROM rust:1.21-jessie AS build
+FROM rust:1.23-jessie AS build
 
 #ENV for build TAG
 ARG BUILD_TAG

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -3,7 +3,7 @@
 
 ### Base Image
 # Setup up a base image to use in Build and Runtime images
-FROM rust:1.21-jessie AS build
+FROM rust:1.23-jessie AS build
 
 # rustup directory
 ENV PATH=/root/.cargo/bin:$PATH \

--- a/message/src/common/command.rs
+++ b/message/src/common/command.rs
@@ -1,5 +1,4 @@
 use std::{str, fmt};
-use std::ascii::AsciiExt;
 use hash::H96;
 use Error;
 


### PR DESCRIPTION
Found warning in https://travis-ci.org/paritytech/parity-bitcoin/builds/339518985 . Reason: https://github.com/rust-lang/rust/pull/44042 . So there are two options to fix this warning - either to add `#[allow(unused_imports)]`, or to bump up minimal required `rustc` version. I prefer to require 1.23. If you know any problems with this - please speak now or forever hold your peace :)