### PR TITLE
Bitcoin Cash: OP_CAT implementation

### DIFF
--- a/primitives/src/bytes.rs
+++ b/primitives/src/bytes.rs
@@ -24,6 +24,10 @@ impl Bytes {
 	pub fn len(&self) -> usize {
 		self.0.len()
 	}
+
+	pub fn append(&mut self, other: &mut Bytes) {
+		self.0.append(&mut other.0);
+	}
 }
 
 impl HeapSizeOf for Bytes {

--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -65,6 +65,9 @@ pub struct VerificationFlags {
 
 	/// Making v1-v16 witness program non-standard
 	pub verify_discourage_upgradable_witness_program: bool,
+
+	/// Support OP_CAT opcode
+	pub verify_concat: bool,
 }
 
 impl VerificationFlags {
@@ -105,6 +108,11 @@ impl VerificationFlags {
 
 	pub fn verify_discourage_upgradable_witness_program(mut self, value: bool) -> Self {
 		self.verify_discourage_upgradable_witness_program = value;
+		self
+	}
+
+	pub fn verify_concat(mut self, value: bool) -> Self {
+		self.verify_concat = value;
 		self
 	}
 }

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -3101,7 +3101,7 @@ mod tests {
 	}
 
 	#[test]
-	fn op_cat_disbled_by_default() {
+	fn op_cat_disabled_by_default() {
 		// maxlen_x empty OP_CAT → ok
 		let script = Builder::default()
 			.push_data(&[1; 1])

--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -1,5 +1,6 @@
 //! Script opcodes.
 use std::fmt;
+use flags::VerificationFlags;
 
 /// Script opcodes.
 #[repr(u8)]
@@ -433,10 +434,11 @@ impl Opcode {
 		}
 	}
 
-	pub fn is_disabled(&self) -> bool {
+	pub fn is_disabled(&self, flags: &VerificationFlags) -> bool {
 		use self::Opcode::*;
 		match *self {
-			OP_CAT | OP_SUBSTR | OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR |
+			OP_CAT if !flags.verify_concat => true,
+			OP_SUBSTR | OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR |
 				OP_XOR | OP_2MUL | OP_2DIV | OP_MUL | OP_DIV | OP_MOD | OP_LSHIFT |
 				OP_RSHIFT => true,
 			_ => false,

--- a/script/src/script.rs
+++ b/script/src/script.rs
@@ -250,7 +250,7 @@ impl Script {
 	}
 
 	pub fn get_instruction(&self, position: usize) -> Result<Instruction, Error> {
-		let opcode = try!(self.get_opcode(position));
+		let opcode = self.get_opcode(position)?;
 		let instruction = match opcode {
 			Opcode::OP_PUSHDATA1 |
 			Opcode::OP_PUSHDATA2 |
@@ -261,9 +261,9 @@ impl Script {
 					_ => 4,
 				};
 
-				let slice = try!(self.take(position + 1, len));
-				let n = try!(read_usize(slice, len));
-				let bytes = try!(self.take(position + 1 + len, n));
+				let slice = self.take(position + 1, len)?;
+				let n = read_usize(slice, len)?;
+				let bytes = self.take(position + 1 + len, n)?;
 				Instruction {
 					opcode: opcode,
 					step: len + n + 1,
@@ -271,7 +271,7 @@ impl Script {
 				}
 			},
 			o if o <= Opcode::OP_PUSHBYTES_75 => {
-				let bytes = try!(self.take(position + 1, opcode as usize));
+				let bytes = self.take(position + 1, opcode as usize)?;
 				Instruction {
 					opcode: o,
 					step: opcode as usize + 1,
@@ -436,7 +436,7 @@ impl Script {
 				while pc < self.len() - 2 {
 					let instruction = self.get_instruction(pc).expect("this method depends on previous check in script_type()");
 					let data = instruction.data.expect("this method depends on previous check in script_type()");
-					let address = try!(Public::from_slice(data)).address_hash();
+					let address = Public::from_slice(data)?.address_hash();
 					addresses.push(ScriptAddress::new_p2pkh(address));
 					pc += instruction.step;
 				}
@@ -559,8 +559,8 @@ impl fmt::Display for Script {
 			};
 
 			match instruction.data {
-				Some(data) => try!(writeln!(f, "{:?} 0x{:?}", instruction.opcode, Bytes::from(data.to_vec()))),
-				None => try!(writeln!(f, "{:?}", instruction.opcode)),
+				Some(data) => writeln!(f, "{:?} 0x{:?}", instruction.opcode, Bytes::from(data.to_vec()))?,
+				None => writeln!(f, "{:?}", instruction.opcode)?,
 			}
 
 			pc += instruction.step;

--- a/script/src/stack.rs
+++ b/script/src/stack.rs
@@ -50,6 +50,11 @@ impl<T> Stack<T> {
 	}
 
 	#[inline]
+	pub fn last_mut(&mut self) -> Result<&mut T, Error> {
+		self.data.last_mut().ok_or(Error::InvalidStackOperation)
+	}
+
+	#[inline]
 	pub fn pop(&mut self) -> Result<T, Error> {
 		self.data.pop().ok_or(Error::InvalidStackOperation)
 	}

--- a/script/src/stack.rs
+++ b/script/src/stack.rs
@@ -62,20 +62,20 @@ impl<T> Stack<T> {
 	#[inline]
 	pub fn top(&self, i: usize) -> Result<&T, Error> {
 		let pos = i + 1;
-		try!(self.require(pos));
+		self.require(pos)?;
 		Ok(&self.data[self.data.len() - pos])
 	}
 
 	#[inline]
 	pub fn remove(&mut self, i: usize) -> Result<T, Error> {
 		let pos = i + 1;
-		try!(self.require(pos));
+		self.require(pos)?;
 		let to_remove = self.data.len() - pos;
 		Ok(self.data.remove(to_remove))
 	}
 
 	pub fn drop(&mut self, i: usize) -> Result<(), Error> {
-		try!(self.require(i));
+		self.require(i)?;
 		let mut j = i;
 		while j > 0 {
 			self.data.pop();
@@ -85,7 +85,7 @@ impl<T> Stack<T> {
 	}
 
 	pub fn dup(&mut self, i: usize) -> Result<(), Error> where T: Clone {
-		try!(self.require(i));
+		self.require(i)?;
 		let mut j = i;
 		while j > 0 {
 			let v = self.data[self.data.len() - i].clone();
@@ -97,7 +97,7 @@ impl<T> Stack<T> {
 
 	pub fn over(&mut self, i: usize) -> Result<(), Error> where T: Clone {
 		let mut j = i * 2;
-		try!(self.require(j));
+		self.require(j)?;
 		let to_clone = j;
 		while j > i {
 			let v = self.data[self.data.len() - to_clone].clone();
@@ -109,7 +109,7 @@ impl<T> Stack<T> {
 
 	pub fn rot(&mut self, i: usize) -> Result<(), Error> {
 		let mut j = i * 3;
-		try!(self.require(j));
+		self.require(j)?;
 		let to_remove = self.data.len() - j;
 		let limit = j - i;
 		while j > limit {
@@ -123,7 +123,7 @@ impl<T> Stack<T> {
 	pub fn swap(&mut self, i: usize) -> Result<(), Error> {
 		let mut j = i * 2;
 		let mut k = i;
-		try!(self.require(j));
+		self.require(j)?;
 		let len = self.data.len();
 		while k > 0 {
 			self.data.swap(len - j, len - k);
@@ -134,14 +134,14 @@ impl<T> Stack<T> {
 	}
 
 	pub fn nip(&mut self) -> Result<(), Error> {
-		try!(self.require(2));
+		self.require(2)?;
 		let len = self.data.len();
 		self.data.swap_remove(len - 2);
 		Ok(())
 	}
 
 	pub fn tuck(&mut self) -> Result<(), Error> where T: Clone {
-		try!(self.require(2));
+		self.require(2)?;
 		let len = self.data.len();
 		let v = self.data[len - 1].clone();
 		self.data.insert(len - 2, v);


### PR DESCRIPTION
on top of #486 (i.e. this PR is for commits: https://github.com/paritytech/parity-bitcoin/pull/487/commits/34239d4fbe2a18c127d98d926d2cbb1d6963bafd + https://github.com/paritytech/parity-bitcoin/pull/487/commits/7beffdfdc982b3ca41f6b91817385b036ef2d5a8)
part of #479 

According to [OP_CAT](https://github.com/schancel/spec/blob/5e9319028e85321c24eac9fe4b47e60c42b315bc/may-2018-reenabled-opcodes.md#op_cat) specification
This PR won't affect consensus, until [May 2018 Hardfork transition](https://github.com/schancel/spec/blob/5e9319028e85321c24eac9fe4b47e60c42b315bc/may-2018-hardfork.md#summary) will be implemented