### PR TITLE
Bitcoin Cash: OP_DIV and OP_MOD implementation

### DIFF
--- a/primitives/src/bytes.rs
+++ b/primitives/src/bytes.rs
@@ -28,6 +28,10 @@ impl Bytes {
 	pub fn append(&mut self, other: &mut Bytes) {
 		self.0.append(&mut other.0);
 	}
+
+	pub fn split_off(&mut self, at: usize) -> Bytes {
+		Bytes(self.0.split_off(at))
+	}
 }
 
 impl HeapSizeOf for Bytes {

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
 	InvalidStackOperation,
 	InvalidAltstackOperation,
 	UnbalancedConditional,
+	InvalidSplitRange,
 
 	// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 	NegativeLocktime,
@@ -92,6 +93,7 @@ impl fmt::Display for Error {
 			Error::InvalidStackOperation => "Invalid stack operation".fmt(f),
 			Error::InvalidAltstackOperation => "Invalid altstack operation".fmt(f),
 			Error::UnbalancedConditional => "Unbalanced conditional".fmt(f),
+			Error::InvalidSplitRange => "Invalid OP_SPLIT range".fmt(f),
 
 			// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 			Error::NegativeLocktime => "Negative locktime".fmt(f),

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
 	UnbalancedConditional,
 	InvalidSplitRange,
 	InvalidBitwiseOperation,
+	DivisionByZero,
 
 	// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 	NegativeLocktime,
@@ -96,6 +97,7 @@ impl fmt::Display for Error {
 			Error::UnbalancedConditional => "Unbalanced conditional".fmt(f),
 			Error::InvalidSplitRange => "Invalid OP_SPLIT range".fmt(f),
 			Error::InvalidBitwiseOperation => "Invalid bitwise operation (check length of inputs)".fmt(f),
+			Error::DivisionByZero => "Invalid division operation".fmt(f),
 
 			// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 			Error::NegativeLocktime => "Negative locktime".fmt(f),

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -33,6 +33,7 @@ pub enum Error {
 	InvalidAltstackOperation,
 	UnbalancedConditional,
 	InvalidSplitRange,
+	InvalidBitwiseOperation,
 
 	// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 	NegativeLocktime,
@@ -94,6 +95,7 @@ impl fmt::Display for Error {
 			Error::InvalidAltstackOperation => "Invalid altstack operation".fmt(f),
 			Error::UnbalancedConditional => "Unbalanced conditional".fmt(f),
 			Error::InvalidSplitRange => "Invalid OP_SPLIT range".fmt(f),
+			Error::InvalidBitwiseOperation => "Invalid bitwise operation (check length of inputs)".fmt(f),
 
 			// CHECKLOCKTIMEVERIFY and CHECKSEQUENCEVERIFY
 			Error::NegativeLocktime => "Negative locktime".fmt(f),

--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -82,6 +82,12 @@ pub struct VerificationFlags {
 
 	/// Support OP_XOR opcode
 	pub verify_xor: bool,
+
+	/// Support OP_DIV opcode
+	pub verify_div: bool,
+
+	/// Support OP_MOD opcode
+	pub verify_mod: bool,
 }
 
 impl VerificationFlags {
@@ -147,6 +153,16 @@ impl VerificationFlags {
 
 	pub fn verify_xor(mut self, value: bool) -> Self {
 		self.verify_xor = value;
+		self
+	}
+
+	pub fn verify_div(mut self, value: bool) -> Self {
+		self.verify_div = value;
+		self
+	}
+
+	pub fn verify_mod(mut self, value: bool) -> Self {
+		self.verify_mod = value;
 		self
 	}
 }

--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -73,6 +73,15 @@ pub struct VerificationFlags {
 	///
 	/// This opcode replaces OP_SUBSTR => enabling both OP_SPLIT && OP_SUBSTR would be an error
 	pub verify_split: bool,
+
+	/// Support OP_AND opcode
+	pub verify_and: bool,
+
+	/// Support OP_OR opcode
+	pub verify_or: bool,
+
+	/// Support OP_XOR opcode
+	pub verify_xor: bool,
 }
 
 impl VerificationFlags {
@@ -123,6 +132,21 @@ impl VerificationFlags {
 
 	pub fn verify_split(mut self, value: bool) -> Self {
 		self.verify_split = value;
+		self
+	}
+
+	pub fn verify_and(mut self, value: bool) -> Self {
+		self.verify_and = value;
+		self
+	}
+
+	pub fn verify_or(mut self, value: bool) -> Self {
+		self.verify_or = value;
+		self
+	}
+
+	pub fn verify_xor(mut self, value: bool) -> Self {
+		self.verify_xor = value;
 		self
 	}
 }

--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -68,6 +68,11 @@ pub struct VerificationFlags {
 
 	/// Support OP_CAT opcode
 	pub verify_concat: bool,
+
+	/// Support OP_SPLIT opcode
+	///
+	/// This opcode replaces OP_SUBSTR => enabling both OP_SPLIT && OP_SUBSTR would be an error
+	pub verify_split: bool,
 }
 
 impl VerificationFlags {
@@ -113,6 +118,11 @@ impl VerificationFlags {
 
 	pub fn verify_concat(mut self, value: bool) -> Self {
 		self.verify_concat = value;
+		self
+	}
+
+	pub fn verify_split(mut self, value: bool) -> Self {
+		self.verify_split = value;
 		self
 	}
 }

--- a/script/src/num.rs
+++ b/script/src/num.rs
@@ -210,3 +210,19 @@ impl ops::Neg for Num {
 		(-self.value).into()
 	}
 }
+
+impl ops::Div for Num {
+	type Output = Self;
+
+	fn div(self, rhs: Self) -> Self::Output {
+		(self.value / rhs.value).into()
+	}
+}
+
+impl ops::Rem for Num {
+	type Output = Self;
+
+	fn rem(self, rhs: Self) -> Self::Output {
+		(self.value % rhs.value).into()
+	}
+}

--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -438,7 +438,8 @@ impl Opcode {
 		use self::Opcode::*;
 		match *self {
 			OP_CAT if !flags.verify_concat => true,
-			OP_SUBSTR | OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR |
+			OP_SUBSTR if !flags.verify_split => true,
+			OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR |
 				OP_XOR | OP_2MUL | OP_2DIV | OP_MUL | OP_DIV | OP_MOD | OP_LSHIFT |
 				OP_RSHIFT => true,
 			_ => false,

--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -439,8 +439,11 @@ impl Opcode {
 		match *self {
 			OP_CAT if !flags.verify_concat => true,
 			OP_SUBSTR if !flags.verify_split => true,
-			OP_LEFT | OP_RIGHT | OP_INVERT | OP_AND | OP_OR |
-				OP_XOR | OP_2MUL | OP_2DIV | OP_MUL | OP_DIV | OP_MOD | OP_LSHIFT |
+			OP_AND if !flags.verify_and => true,
+			OP_OR if !flags.verify_or => true,
+			OP_XOR if !flags.verify_xor => true,
+			OP_LEFT | OP_RIGHT | OP_INVERT | OP_2MUL | OP_2DIV |
+				OP_MUL | OP_DIV | OP_MOD | OP_LSHIFT |
 				OP_RSHIFT => true,
 			_ => false,
 		}

--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -442,9 +442,10 @@ impl Opcode {
 			OP_AND if !flags.verify_and => true,
 			OP_OR if !flags.verify_or => true,
 			OP_XOR if !flags.verify_xor => true,
+			OP_DIV if !flags.verify_div => true,
+			OP_MOD if !flags.verify_mod => true,
 			OP_LEFT | OP_RIGHT | OP_INVERT | OP_2MUL | OP_2DIV |
-				OP_MUL | OP_DIV | OP_MOD | OP_LSHIFT |
-				OP_RSHIFT => true,
+				OP_MUL | OP_LSHIFT | OP_RSHIFT => true,
 			_ => false,
 		}
 	}


### PR DESCRIPTION
on top of #489 (i.e. this PR is for commit: https://github.com/paritytech/parity-bitcoin/commit/06a4ef8dbc409f434796c9a68d6430f56fd22488)
part of #479 

According to [OP_DIV](https://github.com/schancel/spec/blob/5e9319028e85321c24eac9fe4b47e60c42b315bc/may-2018-reenabled-opcodes.md#op_div) and [OP_MOD](https://github.com/schancel/spec/blob/5e9319028e85321c24eac9fe4b47e60c42b315bc/may-2018-reenabled-opcodes.md#op_mod) specification
This PR won't affect consensus, until [May 2018 Hardfork transition](https://github.com/schancel/spec/blob/5e9319028e85321c24eac9fe4b47e60c42b315bc/may-2018-hardfork.md#summary) will be implemented