### PR TITLE
Distinguish BTC and BCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ USAGE:
 
 FLAGS:
         --bch             Use Bitcoin Cash verification rules (BCH).
-        --btc             Enable Bitcoin Core verification rules (BTC).
+        --btc             Use Bitcoin Core verification rules (BTC).
     -h, --help            Prints help information
         --no-jsonrpc      Disable the JSON-RPC API server.
     -q, --quiet           Do not show any synchronization information in the console.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It's also possible to run regtests manually:
 
 ```
 # let's start pbtc in regtest compatible mode
-./target/release/pbtc --segwit --regtest
+./target/release/pbtc --btc --regtest
 
 # now in second shell window
 cd $HOME
@@ -131,24 +131,24 @@ java -jar pull-tests-f56eec3.jar
 
 By default parity connects to bitcoind-seednodes. Full list is [here](./pbtc/seednodes.rs).
 
-Before starting synchronization, you must decide - which fork to follow - SegWit (`--segwit` flag) or Bitcoin Cash (`--bitcoin-cash` flag). On next start, passing the same flag is optional, as the database is already bound to selected fork and won't be synchronized using other verification rules.
+Before starting synchronization, you must decide - which fork to follow - Bitcoin Core (`--btc` flag) or Bitcoin Cash (`--bch` flag). On next start, passing the same flag is optional, as the database is already bound to selected fork and won't be synchronized using other verification rules.
 
 To start syncing the main network, just start the client, passing selected fork flag. For example:
 
 ```
-./target/release/pbtc --segwit
+./target/release/pbtc --btc
 ```
 
 To start syncing the testnet:
 
 ```
-./target/release/pbtc --segwit --testnet
+./target/release/pbtc --btc --testnet
 ```
 
 To not print any syncing progress add `--quiet` flag:
 
 ```
-./target/release/pbtc --segwit --quiet
+./target/release/pbtc --btc --quiet
 ```
 
 ## Importing bitcoind database
@@ -163,7 +163,7 @@ It it is possible to import existing `bitcoind` database:
 By default import verifies imported the blocks. You can disable this, by adding `--verification-level==none` flag.
 
 ```
-./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --segwit --skip-verification
+./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --btc --skip-verification
 ```
 
 ## Command line interface
@@ -179,12 +179,12 @@ USAGE:
     pbtc [FLAGS] [OPTIONS] [SUBCOMMAND]
 
 FLAGS:
-        --bitcoin-cash    Use Bitcoin Cash verification rules.
+        --bch             Use Bitcoin Cash verification rules (BCH).
+        --btc             Enable Bitcoin Core verification rules (BTC).
     -h, --help            Prints help information
         --no-jsonrpc      Disable the JSON-RPC API server.
     -q, --quiet           Do not show any synchronization information in the console.
         --regtest         Use a private network for regression tests.
-        --segwit          Enable SegWit verification rules.
         --testnet         Use the test network (Testnet3).
     -V, --version         Prints version information
 
@@ -338,7 +338,7 @@ This is a section only for developers and power users.
 You can enable detailed client logging by setting the environment variable `RUST_LOG`, e.g.,
 
 ```
-RUST_LOG=verification=info ./target/release/pbtc --segwit
+RUST_LOG=verification=info ./target/release/pbtc --btc
 ```
 
 `pbtc` started with this environment variable will print all logs coming from `verification` module with verbosity `info` or higher. Available log levels are:
@@ -352,7 +352,7 @@ RUST_LOG=verification=info ./target/release/pbtc --segwit
 It's also possible to start logging from multiple modules in the same time:
 
 ```
-RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --segwit
+RUST_LOG=sync=trace,p2p=trace,verification=trace,db=trace ./target/release/pbtc --btc
 ```
 
 ## Internal documentation

--- a/bencher/src/verifier.rs
+++ b/bencher/src/verifier.rs
@@ -94,7 +94,7 @@ pub fn main(benchmark: &mut Benchmark) {
 
 	assert_eq!(store.best_block().hash, rolling_hash);
 
-	let chain_verifier = ChainVerifier::new(store.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+	let chain_verifier = ChainVerifier::new(store.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 
 	// bench
 	benchmark.start();

--- a/message/src/message/message_header.rs
+++ b/message/src/message/message_header.rs
@@ -69,7 +69,7 @@ mod tests {
 	fn test_message_header_serialization() {
 		let expected = "f9beb4d96164647200000000000000001f000000ed52399b".into();
 		let header = MessageHeader {
-			magic: Network::Mainnet.magic(&ConsensusFork::NoFork),
+			magic: Network::Mainnet.magic(&ConsensusFork::BitcoinCore),
 			command: "addr".into(),
 			len: 0x1f,
 			checksum: "ed52399b".into(),
@@ -82,12 +82,12 @@ mod tests {
 	fn test_message_header_deserialization() {
 		let raw: Bytes = "f9beb4d96164647200000000000000001f000000ed52399b".into();
 		let expected = MessageHeader {
-			magic: Network::Mainnet.magic(&ConsensusFork::NoFork),
+			magic: Network::Mainnet.magic(&ConsensusFork::BitcoinCore),
 			command: "addr".into(),
 			len: 0x1f,
 			checksum: "ed52399b".into(),
 		};
 
-		assert_eq!(expected, MessageHeader::deserialize(&raw, Network::Mainnet.magic(&ConsensusFork::NoFork)).unwrap());
+		assert_eq!(expected, MessageHeader::deserialize(&raw, Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).unwrap());
 	}
 }

--- a/network/src/consensus.rs
+++ b/network/src/consensus.rs
@@ -44,7 +44,7 @@ pub struct BitcoinCashConsensusParams {
 /// Concurrent consensus rule forks.
 pub enum ConsensusFork {
 	/// No fork.
-	NoFork,
+	BitcoinCore,
 	/// Bitcoin Cash (aka UAHF).
 	/// `u32` is height of the first block, for which new consensus rules are applied.
 	/// Briefly: no SegWit + blocks up to 8MB + replay protection.
@@ -64,7 +64,7 @@ impl ConsensusParams {
 				bip65_height: 388381,	// 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
 				bip66_height: 363725,	// 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
 				segwit_deployment: match fork {
-					ConsensusFork::NoFork => Some(Deployment {
+					ConsensusFork::BitcoinCore => Some(Deployment {
 						name: "segwit",
 						bit: 1,
 						start_time: 1479168000,
@@ -91,7 +91,7 @@ impl ConsensusParams {
 				bip65_height: 581885,	// 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
 				bip66_height: 330776,	// 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
 				segwit_deployment: match fork {
-					ConsensusFork::NoFork => Some(Deployment {
+					ConsensusFork::BitcoinCore => Some(Deployment {
 						name: "segwit",
 						bit: 1,
 						start_time: 1462060800,
@@ -118,7 +118,7 @@ impl ConsensusParams {
 				bip65_height: 1351,
 				bip66_height: 1251,		// used only in rpc tests
 				segwit_deployment: match fork {
-					ConsensusFork::NoFork => Some(Deployment {
+					ConsensusFork::BitcoinCore => Some(Deployment {
 						name: "segwit",
 						bit: 1,
 						start_time: 0,
@@ -169,7 +169,7 @@ impl ConsensusFork {
 
 	pub fn activation_height(&self) -> u32 {
 		match *self {
-			ConsensusFork::NoFork => 0,
+			ConsensusFork::BitcoinCore => 0,
 			ConsensusFork::BitcoinCash(ref fork) => fork.height,
 		}
 	}
@@ -184,14 +184,14 @@ impl ConsensusFork {
 		match *self {
 			// size of first fork block must be larger than 1MB
 			ConsensusFork::BitcoinCash(ref fork) if height == fork.height => 1_000_001,
-			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => 0,
+			ConsensusFork::BitcoinCore | ConsensusFork::BitcoinCash(_) => 0,
 		}
 	}
 
 	pub fn max_block_size(&self, height: u32) -> usize {
 		match *self {
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => 8_000_000,
-			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => 1_000_000,
+			ConsensusFork::BitcoinCore | ConsensusFork::BitcoinCash(_) => 1_000_000,
 		}
 	}
 
@@ -200,7 +200,7 @@ impl ConsensusFork {
 			// according to REQ-5: max_block_sigops = 20000 * ceil((max(blocksize_bytes, 1000000) / 1000000))
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height =>
 				20_000 * (1 + (block_size - 1) / 1_000_000),
-			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => 20_000,
+			ConsensusFork::BitcoinCore | ConsensusFork::BitcoinCash(_) => 20_000,
 		}
 	}
 
@@ -208,14 +208,14 @@ impl ConsensusFork {
 		match *self {
 			ConsensusFork::BitcoinCash(_) =>
 				self.max_block_sigops(height, block_size) * Self::witness_scale_factor(),
-			ConsensusFork::NoFork =>
+			ConsensusFork::BitcoinCore =>
 				80_000,
 		}
 	}
 
 	pub fn max_block_weight(&self, _height: u32) -> usize {
 		match *self {
-			ConsensusFork::NoFork =>
+			ConsensusFork::BitcoinCore =>
 				4_000_000,
 			ConsensusFork::BitcoinCash(_) =>
 				unreachable!("BitcoinCash has no SegWit; weight is only checked with SegWit activated; qed"),
@@ -249,42 +249,42 @@ mod tests {
 
 	#[test]
 	fn test_consensus_params_bip34_height() {
-		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork).bip34_height, 227931);
-		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork).bip34_height, 21111);
-		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::NoFork).bip34_height, 100000000);
+		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore).bip34_height, 227931);
+		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore).bip34_height, 21111);
+		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::BitcoinCore).bip34_height, 100000000);
 	}
 
 	#[test]
 	fn test_consensus_params_bip65_height() {
-		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork).bip65_height, 388381);
-		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork).bip65_height, 581885);
-		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::NoFork).bip65_height, 1351);
+		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore).bip65_height, 388381);
+		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore).bip65_height, 581885);
+		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::BitcoinCore).bip65_height, 1351);
 	}
 
 	#[test]
 	fn test_consensus_params_bip66_height() {
-		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork).bip66_height, 363725);
-		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork).bip66_height, 330776);
-		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::NoFork).bip66_height, 1251);
+		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore).bip66_height, 363725);
+		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore).bip66_height, 330776);
+		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::BitcoinCore).bip66_height, 1251);
 	}
 
 	#[test]
 	fn test_consensus_activation_threshold() {
-		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork).rule_change_activation_threshold, 1916);
-		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork).rule_change_activation_threshold, 1512);
-		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::NoFork).rule_change_activation_threshold, 108);
+		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore).rule_change_activation_threshold, 1916);
+		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore).rule_change_activation_threshold, 1512);
+		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::BitcoinCore).rule_change_activation_threshold, 108);
 	}
 
 	#[test]
 	fn test_consensus_miner_confirmation_window() {
-		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork).miner_confirmation_window, 2016);
-		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork).miner_confirmation_window, 2016);
-		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::NoFork).miner_confirmation_window, 144);
+		assert_eq!(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore).miner_confirmation_window, 2016);
+		assert_eq!(ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore).miner_confirmation_window, 2016);
+		assert_eq!(ConsensusParams::new(Network::Regtest, ConsensusFork::BitcoinCore).miner_confirmation_window, 144);
 	}
 
 	#[test]
 	fn test_consensus_fork_min_block_size() {
-		assert_eq!(ConsensusFork::NoFork.min_block_size(0), 0);
+		assert_eq!(ConsensusFork::BitcoinCore.min_block_size(0), 0);
 		let fork = ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(Network::Mainnet));
 		assert_eq!(fork.min_block_size(0), 0);
 		assert_eq!(fork.min_block_size(fork.activation_height()), 1_000_001);
@@ -292,13 +292,13 @@ mod tests {
 
 	#[test]
 	fn test_consensus_fork_max_transaction_size() {
-		assert_eq!(ConsensusFork::NoFork.max_transaction_size(), 1_000_000);
+		assert_eq!(ConsensusFork::BitcoinCore.max_transaction_size(), 1_000_000);
 		assert_eq!(ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(Network::Mainnet)).max_transaction_size(), 1_000_000);
 	}
 
 	#[test]
 	fn test_consensus_fork_max_block_sigops() {
-		assert_eq!(ConsensusFork::NoFork.max_block_sigops(0, 1_000_000), 20_000);
+		assert_eq!(ConsensusFork::BitcoinCore.max_block_sigops(0, 1_000_000), 20_000);
 		let fork = ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(Network::Mainnet));
 		assert_eq!(fork.max_block_sigops(0, 1_000_000), 20_000);
 		assert_eq!(fork.max_block_sigops(fork.activation_height(), 2_000_000), 40_000);

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -110,10 +110,10 @@ mod tests {
 
 	#[test]
 	fn test_network_magic_number() {
-		assert_eq!(MAGIC_MAINNET, Network::Mainnet.magic(&ConsensusFork::NoFork));
-		assert_eq!(MAGIC_TESTNET, Network::Testnet.magic(&ConsensusFork::NoFork));
-		assert_eq!(MAGIC_REGTEST, Network::Regtest.magic(&ConsensusFork::NoFork));
-		assert_eq!(MAGIC_UNITEST, Network::Unitest.magic(&ConsensusFork::NoFork));
+		assert_eq!(MAGIC_MAINNET, Network::Mainnet.magic(&ConsensusFork::BitcoinCore));
+		assert_eq!(MAGIC_TESTNET, Network::Testnet.magic(&ConsensusFork::BitcoinCore));
+		assert_eq!(MAGIC_REGTEST, Network::Regtest.magic(&ConsensusFork::BitcoinCore));
+		assert_eq!(MAGIC_UNITEST, Network::Unitest.magic(&ConsensusFork::BitcoinCore));
 	}
 
 	#[test]

--- a/p2p/src/io/handshake.rs
+++ b/p2p/src/io/handshake.rs
@@ -287,7 +287,7 @@ mod tests {
 
 	#[test]
 	fn test_handshake() {
-		let magic = Network::Mainnet.magic(&ConsensusFork::NoFork);
+		let magic = Network::Mainnet.magic(&ConsensusFork::BitcoinCore);
 		let version = 70012;
 		let local_version = local_version();
 		let remote_version = remote_version();
@@ -317,7 +317,7 @@ mod tests {
 
 	#[test]
 	fn test_accept_handshake() {
-		let magic = Network::Mainnet.magic(&ConsensusFork::NoFork);
+		let magic = Network::Mainnet.magic(&ConsensusFork::BitcoinCore);
 		let version = 70012;
 		let local_version = local_version();
 		let remote_version = remote_version();
@@ -346,7 +346,7 @@ mod tests {
 
 	#[test]
 	fn test_self_handshake() {
-		let magic = Network::Mainnet.magic(&ConsensusFork::NoFork);
+		let magic = Network::Mainnet.magic(&ConsensusFork::BitcoinCore);
 		let version = 70012;
 		let remote_version = local_version();
 		let local_version = local_version();
@@ -367,7 +367,7 @@ mod tests {
 
 	#[test]
 	fn test_accept_self_handshake() {
-		let magic = Network::Mainnet.magic(&ConsensusFork::NoFork);
+		let magic = Network::Mainnet.magic(&ConsensusFork::BitcoinCore);
 		let version = 70012;
 		let remote_version = local_version();
 		let local_version = local_version();
@@ -388,7 +388,7 @@ mod tests {
 
 	#[test]
 	fn test_fails_to_accept_other_fork_node() {
-		let magic1 = Network::Mainnet.magic(&ConsensusFork::NoFork);
+		let magic1 = Network::Mainnet.magic(&ConsensusFork::BitcoinCore);
 		let magic2 = Network::Mainnet.magic(&ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(Network::Mainnet)));
 		let version = 70012;
 		let local_version = local_version();

--- a/p2p/src/io/read_any_message.rs
+++ b/p2p/src/io/read_any_message.rs
@@ -74,20 +74,20 @@ mod tests {
 		let nonce = "5845303b6da97786".into();
 		let expected = (name, nonce);
 
-		assert_eq!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork)).wait().unwrap(), Ok(expected));
-		assert_eq!(read_any_message(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::NoFork)).wait().unwrap(), Err(Error::InvalidMagic));
+		assert_eq!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap(), Ok(expected));
+		assert_eq!(read_any_message(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap(), Err(Error::InvalidMagic));
 	}
 
 	#[test]
 	fn test_read_too_short_any_message() {
 		let raw: Bytes = "f9beb4d970696e6700000000000000000800000083c00c765845303b6da977".into();
-		assert!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork)).wait().is_err());
+		assert!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).wait().is_err());
 	}
 
 
 	#[test]
 	fn test_read_any_message_with_invalid_checksum() {
 		let raw: Bytes = "f9beb4d970696e6700000000000000000800000083c01c765845303b6da97786".into();
-		assert_eq!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork)).wait().unwrap(), Err(Error::InvalidChecksum));
+		assert_eq!(read_any_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap(), Err(Error::InvalidChecksum));
 	}
 }

--- a/p2p/src/io/read_header.rs
+++ b/p2p/src/io/read_header.rs
@@ -40,25 +40,25 @@ mod tests {
 	fn test_read_header() {
 		let raw: Bytes = "f9beb4d96164647200000000000000001f000000ed52399b".into();
 		let expected = MessageHeader {
-			magic: Network::Mainnet.magic(&ConsensusFork::NoFork),
+			magic: Network::Mainnet.magic(&ConsensusFork::BitcoinCore),
 			command: "addr".into(),
 			len: 0x1f,
 			checksum: "ed52399b".into(),
 		};
 
-		assert_eq!(read_header(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork)).wait().unwrap().1, Ok(expected));
-		assert_eq!(read_header(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::NoFork)).wait().unwrap().1, Err(Error::InvalidMagic));
+		assert_eq!(read_header(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap().1, Ok(expected));
+		assert_eq!(read_header(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap().1, Err(Error::InvalidMagic));
 	}
 
 	#[test]
 	fn test_read_header_with_invalid_magic() {
 		let raw: Bytes = "f9beb4d86164647200000000000000001f000000ed52399b".into();
-		assert_eq!(read_header(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::NoFork)).wait().unwrap().1, Err(Error::InvalidMagic));
+		assert_eq!(read_header(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::BitcoinCore)).wait().unwrap().1, Err(Error::InvalidMagic));
 	}
 
 	#[test]
 	fn test_read_too_short_header() {
 		let raw: Bytes = "f9beb4d96164647200000000000000001f000000ed5239".into();
-		assert!(read_header(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork)).wait().is_err());
+		assert!(read_header(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore)).wait().is_err());
 	}
 }

--- a/p2p/src/io/read_message.rs
+++ b/p2p/src/io/read_message.rs
@@ -78,21 +78,21 @@ mod tests {
 	fn test_read_message() {
 		let raw: Bytes = "f9beb4d970696e6700000000000000000800000083c00c765845303b6da97786".into();
 		let ping = Ping::new(u64::from_str_radix("8677a96d3b304558", 16).unwrap());
-		assert_eq!(read_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork), 0).wait().unwrap().1, Ok(ping));
-		assert_eq!(read_message::<Ping, _>(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::NoFork), 0).wait().unwrap().1, Err(Error::InvalidMagic));
-		assert_eq!(read_message::<Pong, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork), 0).wait().unwrap().1, Err(Error::InvalidCommand));
+		assert_eq!(read_message(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore), 0).wait().unwrap().1, Ok(ping));
+		assert_eq!(read_message::<Ping, _>(raw.as_ref(), Network::Testnet.magic(&ConsensusFork::BitcoinCore), 0).wait().unwrap().1, Err(Error::InvalidMagic));
+		assert_eq!(read_message::<Pong, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore), 0).wait().unwrap().1, Err(Error::InvalidCommand));
 	}
 
 	#[test]
 	fn test_read_too_short_message() {
 		let raw: Bytes = "f9beb4d970696e6700000000000000000800000083c00c765845303b6da977".into();
-		assert!(read_message::<Ping, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork), 0).wait().is_err());
+		assert!(read_message::<Ping, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore), 0).wait().is_err());
 	}
 
 
 	#[test]
 	fn test_read_message_with_invalid_checksum() {
 		let raw: Bytes = "f9beb4d970696e6700000000000000000800000083c01c765845303b6da97786".into();
-		assert_eq!(read_message::<Ping, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::NoFork), 0).wait().unwrap().1, Err(Error::InvalidChecksum));
+		assert_eq!(read_message::<Ping, _>(raw.as_ref(), Network::Mainnet.magic(&ConsensusFork::BitcoinCore), 0).wait().unwrap().1, Err(Error::InvalidChecksum));
 	}
 }

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -11,7 +11,7 @@ args:
         help: Use a private network for regression tests.
     - btc:
         long: btc
-        help: Enable Bitcoin Core verification rules (BTC).
+        help: Use Bitcoin Core verification rules (BTC).
     - bch:
         long: bch
         help: Use Bitcoin Cash verification rules (BCH).

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -9,12 +9,12 @@ args:
     - regtest:
         long: regtest
         help: Use a private network for regression tests.
-    - segwit:
-        long: segwit
-        help: Enable SegWit verification rules.
-    - bitcoin-cash:
-        long: bitcoin-cash
-        help: Use Bitcoin Cash verification rules.
+    - btc:
+        long: btc
+        help: Enable Bitcoin Core verification rules (BTC).
+    - bch:
+        long: bch
+        help: Use Bitcoin Cash verification rules (BCH).
     - connect:
         short: c
         long: connect

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -169,14 +169,14 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 
 fn parse_consensus_fork(network: Network, db: &storage::SharedStore, matches: &clap::ArgMatches) -> Result<ConsensusFork, String> {
 	let old_consensus_fork = db.consensus_fork()?;
-	let new_consensus_fork = match (matches.is_present("segwit"), matches.is_present("bitcoin-cash")) {
+	let new_consensus_fork = match (matches.is_present("btc"), matches.is_present("bch")) {
 		(false, false) => match &old_consensus_fork {
 			&Some(ref old_consensus_fork) => old_consensus_fork,
-			&None => return Err("You must select fork on first run: --segwit, --bitcoin-cash".into()),
+			&None => return Err("You must select fork on first run: --btc, --bch".into()),
 		},
-		(true, false) => "segwit",
-		(false, true) => "bitcoin-cash",
-		_ => return Err("You can only pass single fork argument: --segwit, --bitcoin-cash".into()),
+		(true, false) => "btc",
+		(false, true) => "bch",
+		_ => return Err("You can only pass single fork argument: --btc, --bch".into()),
 	};
 
 	match &old_consensus_fork {
@@ -187,8 +187,8 @@ fn parse_consensus_fork(network: Network, db: &storage::SharedStore, matches: &c
 	}
 
 	Ok(match new_consensus_fork {
-		"segwit" => ConsensusFork::BitcoinCore,
-		"bitcoin-cash" => ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(network)),
+		"btc" => ConsensusFork::BitcoinCore,
+		"bch" => ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(network)),
 		_ => unreachable!("hardcoded above"),
 	})
 }

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -72,7 +72,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 
 	// to skip idiotic 30 seconds delay in test-scripts
 	let user_agent_suffix = match consensus.fork {
-		ConsensusFork::NoFork => "",
+		ConsensusFork::BitcoinCore => "",
 		ConsensusFork::BitcoinCash(_) => "/UAHF",
 	};
 	let user_agent = match network {
@@ -121,7 +121,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 	let services = Services::default().with_network(true);
 	let services = match &consensus.fork {
 		&ConsensusFork::BitcoinCash(_) => services.with_bitcoin_cash(true),
-		&ConsensusFork::NoFork => services.with_witness(true),
+		&ConsensusFork::BitcoinCore => services.with_witness(true),
 	};
 
 	let verification_level = match matches.value_of("verification-level") {
@@ -187,7 +187,7 @@ fn parse_consensus_fork(network: Network, db: &storage::SharedStore, matches: &c
 	}
 
 	Ok(match new_consensus_fork {
-		"segwit" => ConsensusFork::NoFork,
+		"segwit" => ConsensusFork::BitcoinCore,
 		"bitcoin-cash" => ConsensusFork::BitcoinCash(BitcoinCashConsensusParams::new(network)),
 		_ => unreachable!("hardcoded above"),
 	})

--- a/sync/src/blocks_writer.rs
+++ b/sync/src/blocks_writer.rs
@@ -163,7 +163,7 @@ mod tests {
 	#[test]
 	fn blocks_writer_appends_blocks() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork), default_verification_params());
+		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore), default_verification_params());
 		blocks_target.append_block(test_data::block_h1().into()).expect("Expecting no error");
 		assert_eq!(db.best_block().number, 1);
 	}
@@ -172,7 +172,7 @@ mod tests {
 	fn blocks_writer_verification_error() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let blocks = test_data::build_n_empty_blocks_from_genesis((MAX_ORPHANED_BLOCKS + 2) as u32, 1);
-		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork), default_verification_params());
+		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore), default_verification_params());
 		for (index, block) in blocks.into_iter().skip(1).enumerate() {
 			match blocks_target.append_block(block.into()) {
 				Err(Error::TooManyOrphanBlocks) if index == MAX_ORPHANED_BLOCKS => (),
@@ -186,7 +186,7 @@ mod tests {
 	#[test]
 	fn blocks_writer_out_of_order_block() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork), default_verification_params());
+		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore), default_verification_params());
 
 		let wrong_block = test_data::block_builder()
 			.header().parent(test_data::genesis().hash()).build()
@@ -201,7 +201,7 @@ mod tests {
 	#[test]
 	fn blocks_writer_append_to_existing_db() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::NoFork), default_verification_params());
+		let mut blocks_target = BlocksWriter::new(db.clone(), ConsensusParams::new(Network::Testnet, ConsensusFork::BitcoinCore), default_verification_params());
 
 		assert!(blocks_target.append_block(test_data::genesis().into()).is_ok());
 		assert_eq!(db.best_block().number, 0);

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -374,12 +374,12 @@ pub mod tests {
 		let memory_pool = Arc::new(RwLock::new(MemoryPool::new()));
 		let storage = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let sync_state = SynchronizationStateRef::new(SynchronizationState::with_storage(storage.clone()));
-		let chain = Chain::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), memory_pool.clone());
+		let chain = Chain::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), memory_pool.clone());
 		let sync_peers = Arc::new(PeersImpl::default());
 		let executor = DummyTaskExecutor::new();
 		let server = Arc::new(DummyServer::new());
 		let config = Config { close_connection_on_bad_block: true };
-		let chain_verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork)));
+		let chain_verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore)));
 		let client_core = SynchronizationClientCore::new(config, sync_state.clone(), sync_peers.clone(), executor.clone(), chain, chain_verifier);
 		let mut verifier = match verifier {
 			Some(verifier) => verifier,
@@ -387,7 +387,7 @@ pub mod tests {
 		};
 		verifier.set_sink(Arc::new(CoreVerificationSink::new(client_core.clone())));
 		let client = SynchronizationClient::new(sync_state.clone(), client_core, verifier);
-		let local_node = LocalNode::new(ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork), storage, memory_pool, sync_peers, sync_state, executor.clone(), client, server.clone());
+		let local_node = LocalNode::new(ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore), storage, memory_pool, sync_peers, sync_state, executor.clone(), client, server.clone());
 		(executor, server, local_node)
 	}
 

--- a/sync/src/synchronization_chain.rs
+++ b/sync/src/synchronization_chain.rs
@@ -752,7 +752,7 @@ mod tests {
 	fn chain_empty() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let db_best_block = db.best_block();
-		let chain = Chain::new(db.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let chain = Chain::new(db.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		assert_eq!(chain.information().scheduled, 0);
 		assert_eq!(chain.information().requested, 0);
 		assert_eq!(chain.information().verifying, 0);
@@ -769,7 +769,7 @@ mod tests {
 	#[test]
 	fn chain_block_path() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 
 		// add 6 blocks to scheduled queue
 		let blocks = test_data::build_n_empty_blocks_from_genesis(6, 0);
@@ -821,7 +821,7 @@ mod tests {
 	#[test]
 	fn chain_block_locator_hashes() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		let genesis_hash = chain.best_block().hash;
 		assert_eq!(chain.block_locator_hashes(), vec![genesis_hash.clone()]);
 
@@ -906,7 +906,7 @@ mod tests {
 	#[test]
 	fn chain_transaction_state() {
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		let genesis_block = test_data::genesis();
 		let block1 = test_data::block_h1();
 		let tx1: Transaction = test_data::TransactionBuilder::with_version(1).into();
@@ -943,7 +943,7 @@ mod tests {
 		let tx2_hash = tx2.hash();
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![b0.into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.verify_transaction(tx1.into());
 		chain.insert_verified_transaction(tx2.into());
 
@@ -967,7 +967,7 @@ mod tests {
 			.set_default_input(0).set_output(400).store(test_chain);		// t4
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.verify_transaction(test_chain.at(0).into());
 		chain.verify_transaction(test_chain.at(1).into());
 		chain.verify_transaction(test_chain.at(2).into());
@@ -989,7 +989,7 @@ mod tests {
 			.set_default_input(0).set_output(400).store(test_chain);		// t4
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.insert_verified_transaction(test_chain.at(0).into());
 		chain.insert_verified_transaction(test_chain.at(1).into());
 		chain.insert_verified_transaction(test_chain.at(2).into());
@@ -1015,7 +1015,7 @@ mod tests {
 		let tx2_hash = tx2.hash();
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![b0.into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.verify_transaction(tx1.into());
 		chain.insert_verified_transaction(tx2.into());
 
@@ -1063,7 +1063,7 @@ mod tests {
 		let tx5 = b5.transactions[0].clone();
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![genesis.into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 
 		chain.insert_verified_transaction(tx3.into());
 		chain.insert_verified_transaction(tx4.into());
@@ -1107,7 +1107,7 @@ mod tests {
 
 		// insert tx2 to memory pool
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.insert_verified_transaction(tx2.clone().into());
 		chain.insert_verified_transaction(tx3.clone().into());
 		// insert verified block with tx1
@@ -1126,7 +1126,7 @@ mod tests {
 			.reset().set_input(&data_chain.at(0), 0).add_output(30).store(data_chain);			// transaction0 -> transaction2
 
 		let db = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), Arc::new(RwLock::new(MemoryPool::new())));
+		let mut chain = Chain::new(db, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), Arc::new(RwLock::new(MemoryPool::new())));
 		chain.insert_verified_transaction(data_chain.at(1).into());
 		assert_eq!(chain.information().transactions.transactions_count, 1);
 		chain.insert_verified_transaction(data_chain.at(2).into());

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -1319,11 +1319,11 @@ pub mod tests {
 		};
 		let sync_state = SynchronizationStateRef::new(SynchronizationState::with_storage(storage.clone()));
 		let memory_pool = Arc::new(RwLock::new(MemoryPool::new()));
-		let chain = Chain::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork), memory_pool.clone());
+		let chain = Chain::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore), memory_pool.clone());
 		let executor = DummyTaskExecutor::new();
 		let config = Config { close_connection_on_bad_block: true };
 
-		let chain_verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork)));
+		let chain_verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore)));
 		let client_core = SynchronizationClientCore::new(config, sync_state.clone(), sync_peers.clone(), executor.clone(), chain, chain_verifier.clone());
 		{
 			client_core.lock().set_verify_headers(false);

--- a/sync/src/synchronization_verifier.rs
+++ b/sync/src/synchronization_verifier.rs
@@ -351,7 +351,7 @@ pub mod tests {
 	#[test]
 	fn verifier_wrapper_switches_to_full_mode() {
 		let storage: StorageRef = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork)));
+		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore)));
 
 		// switching to full verification when block is already in db
 		assert_eq!(ChainVerifierWrapper::new(verifier.clone(), &storage, VerificationParameters {
@@ -392,7 +392,7 @@ pub mod tests {
 		let coinbase_transaction_hash = blocks[0].transactions[0].hash.clone();
 		let last_block_hash = blocks[blocks.len() - 1].hash().clone();
 		let storage: StorageRef = Arc::new(BlockChainDatabase::init_test_chain(blocks));
-		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork)));
+		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore)));
 		let bad_transaction_block: IndexedBlock = test_data::block_builder()
 			.transaction().coinbase().output().value(50).build().build()
 			.transaction()
@@ -424,7 +424,7 @@ pub mod tests {
 	#[test]
 	fn verification_level_none_accept_incorrect_block() {
 		let storage: StorageRef = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
-		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork)));
+		let verifier = Arc::new(ChainVerifier::new(storage.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore)));
 		let bad_block: IndexedBlock = test_data::block_builder().header().build().build().into();
 
 		// Ok(()) when nothing is verified

--- a/tools/regtests.sh
+++ b/tools/regtests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./target/release/pbtc --segwit --regtest --db-cache=192 &
+./target/release/pbtc --btc --regtest --db-cache=192 &
 ! java -jar ./tools/compare-tool/pull-tests-be0eef7.jar /tmp/regtest-db 2>&1 | tee regtests-full.log | grep -E --color=auto 'org.bitcoinj.store.BlockStoreException\:|BitcoindComparisonTool.main\: ERROR|bitcoind sent us a block it already had, make sure bitcoind has no blocks!|java.lang.NullPointerException'
 GREP_COLOR="01;32" grep 'BitcoindComparisonTool.main: Block "b1001" completed processing' regtests-full.log
 result=$?

--- a/verification/src/accept_transaction.rs
+++ b/verification/src/accept_transaction.rs
@@ -313,7 +313,7 @@ impl<'a> TransactionEval<'a> {
 		let verify_dersig = height >= params.bip66_height;
 		let signature_version = match params.fork {
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => SignatureVersion::ForkId,
-			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => SignatureVersion::Base,
+			ConsensusFork::BitcoinCore | ConsensusFork::BitcoinCash(_) => SignatureVersion::Base,
 		};
 
 		let verify_checksequence = deployments.csv();
@@ -498,7 +498,7 @@ mod tests {
 		let checker = TransactionReturnReplayProtection::new(CanonTransaction::new(&transaction), &consensus, consensus.fork.activation_height() - 1);
 		assert_eq!(checker.check(), Ok(()));
 
-		let consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork);
+		let consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore);
 		let checker = TransactionReturnReplayProtection::new(CanonTransaction::new(&transaction), &consensus, 100);
 		assert_eq!(checker.check(), Ok(()));
 	}

--- a/verification/src/chain_verifier.rs
+++ b/verification/src/chain_verifier.rs
@@ -154,7 +154,7 @@ mod tests {
 	fn verify_orphan() {
 		let storage = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let b2 = test_data::block_h2().into();
-		let verifier = ChainVerifier::new(storage, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(storage, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert_eq!(Err(Error::Database(DBError::UnknownParent)), verifier.verify(VerificationLevel::Full, &b2));
 	}
 
@@ -162,7 +162,7 @@ mod tests {
 	fn verify_smoky() {
 		let storage = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let b1 = test_data::block_h1();
-		let verifier = ChainVerifier::new(storage, ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(storage, ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert!(verifier.verify(VerificationLevel::Full, &b1.into()).is_ok());
 	}
 
@@ -175,7 +175,7 @@ mod tests {
 				test_data::block_h1().into(),
 			]);
 		let b1 = test_data::block_h2();
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert!(verifier.verify(VerificationLevel::Full, &b1.into()).is_ok());
 	}
 
@@ -204,7 +204,7 @@ mod tests {
 			.merkled_header().parent(genesis.hash()).build()
 			.build();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 
 		let expected = Err(Error::Transaction(
 			1,
@@ -242,7 +242,7 @@ mod tests {
 			.merkled_header().parent(genesis.hash()).build()
 			.build();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert!(verifier.verify(VerificationLevel::Full, &block.into()).is_ok());
 	}
 
@@ -278,7 +278,7 @@ mod tests {
 			.merkled_header().parent(genesis.hash()).build()
 			.build();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert!(verifier.verify(VerificationLevel::Full, &block.into()).is_ok());
 	}
 
@@ -317,7 +317,7 @@ mod tests {
 			.merkled_header().parent(genesis.hash()).build()
 			.build();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 
 		let expected = Err(Error::Transaction(2, TransactionError::Overspend));
 		assert_eq!(expected, verifier.verify(VerificationLevel::Full, &block.into()));
@@ -359,7 +359,7 @@ mod tests {
 			.merkled_header().parent(best_hash).build()
 			.build();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		assert!(verifier.verify(VerificationLevel::Full, &block.into()).is_ok());
 	}
 
@@ -406,7 +406,7 @@ mod tests {
 			.build()
 			.into();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 		let expected = Err(Error::MaximumSigops);
 		assert_eq!(expected, verifier.verify(VerificationLevel::Full, &block.into()));
 	}
@@ -428,7 +428,7 @@ mod tests {
 			.build()
 			.into();
 
-		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::NoFork));
+		let verifier = ChainVerifier::new(Arc::new(storage), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
 
 		let expected = Err(Error::CoinbaseOverspend {
 			expected_max: 5000000000,

--- a/verification/src/work_bch.rs
+++ b/verification/src/work_bch.rs
@@ -133,7 +133,7 @@ fn work_required_bitcoin_cash_adjusted(parent_header: IndexedBlockHeader, time: 
 		// 2^256 - W as the complement of W.
 		(!work) / work
 	}
- 
+
 	// This cannot handle the genesis block and early blocks in general.
 	debug_assert!(height > 0);
 
@@ -213,7 +213,7 @@ mod tests {
 	// https://github.com/bitcoinclassic/bitcoinclassic/blob/8bf1fb856df44d1b790b0b835e4c1969be736e25/src/test/pow_tests.cpp#L108
 	#[test]
 	fn bitcoin_cash_req7() {
-		let main_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::NoFork);
+		let main_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore);
 		let uahf_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCash(BitcoinCashConsensusParams {
 			height: 1000,
 			difficulty_adjustion_height: 0xffffffff,


### PR DESCRIPTION
TL;DR clean up with some historical terms like Segwit versus UAHF:

     --bch             Use Bitcoin Cash verification rules (BCH).
     --btc             Use Bitcoin Core verification rules (BTC).

Also renamed `ConsensusFork::NoFork to ::BitcoinCore`, I was a bit pedantic about that :-p