### PR TITLE
Bitcoin Cash: monolith activation

### DIFF
--- a/network/src/consensus.rs
+++ b/network/src/consensus.rs
@@ -38,9 +38,9 @@ pub struct BitcoinCashConsensusParams {
 	/// Height of difficulty adjustment hardfork.
 	/// https://reviews.bitcoinabc.org/D601
 	pub difficulty_adjustion_height: u32,
-	/// Height of monolith (aka May 2018) hardfork.
+	/// Time of monolith (aka May 2018) hardfork.
 	/// https://github.com/bitcoincashorg/spec/blob/4fbb0face661e293bcfafe1a2a4744dcca62e50d/may-2018-hardfork.md
-	pub monolith_height: u32,
+	pub monolith_time: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -191,9 +191,9 @@ impl ConsensusFork {
 		}
 	}
 
-	pub fn max_block_size(&self, height: u32) -> usize {
+	pub fn max_block_size(&self, height: u32, median_time_past: u32) -> usize {
 		match *self {
-			ConsensusFork::BitcoinCash(ref fork) if height >= fork.monolith_height => 32_000_000,
+			ConsensusFork::BitcoinCash(ref fork) if median_time_past >= fork.monolith_time => 32_000_000,
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => 8_000_000,
 			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => 1_000_000,
 		}
@@ -233,17 +233,17 @@ impl BitcoinCashConsensusParams {
 			Network::Mainnet | Network::Other(_) => BitcoinCashConsensusParams {
 				height: 478559,
 				difficulty_adjustion_height: 504031,
-				monolith_height: ::std::u32::MAX, // TODO: change me + tests
+				monolith_time: 1526400000,
 			},
 			Network::Testnet => BitcoinCashConsensusParams {
 				height: 1155876,
 				difficulty_adjustion_height: 1188697,
-				monolith_height: ::std::u32::MAX, // TODO: change me
+				monolith_time: 1526400000,
 			},
 			Network::Regtest | Network::Unitest => BitcoinCashConsensusParams {
 				height: 0,
 				difficulty_adjustion_height: 0,
-				monolith_height: ::std::u32::MAX, // TODO: change me
+				monolith_time: 1526400000,
 			},
 		}
 	}

--- a/network/src/consensus.rs
+++ b/network/src/consensus.rs
@@ -35,9 +35,12 @@ pub struct ConsensusParams {
 pub struct BitcoinCashConsensusParams {
 	/// Initial BCH hard fork height.
 	pub height: u32,
-	/// Time when difficulty adjustment hardfork becomes active.
+	/// Height of difficulty adjustment hardfork.
 	/// https://reviews.bitcoinabc.org/D601
 	pub difficulty_adjustion_height: u32,
+	/// Height of monolith (aka May 2018) hardfork.
+	/// https://github.com/bitcoincashorg/spec/blob/4fbb0face661e293bcfafe1a2a4744dcca62e50d/may-2018-hardfork.md
+	pub monolith_height: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -154,7 +157,7 @@ impl ConsensusParams {
 impl ConsensusFork {
 	/// Absolute (across all forks) maximum block size. Currently is 8MB for post-HF BitcoinCash
 	pub fn absolute_maximum_block_size() -> usize {
-		8_000_000
+		32_000_000
 	}
 
 	/// Absolute (across all forks) maximum number of sigops in single block. Currently is max(sigops) for 8MB post-HF BitcoinCash block
@@ -190,6 +193,7 @@ impl ConsensusFork {
 
 	pub fn max_block_size(&self, height: u32) -> usize {
 		match *self {
+			ConsensusFork::BitcoinCash(ref fork) if height >= fork.monolith_height => 32_000_000,
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => 8_000_000,
 			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => 1_000_000,
 		}
@@ -229,14 +233,17 @@ impl BitcoinCashConsensusParams {
 			Network::Mainnet | Network::Other(_) => BitcoinCashConsensusParams {
 				height: 478559,
 				difficulty_adjustion_height: 504031,
+				monolith_height: ::std::u32::MAX, // TODO: change me + tests
 			},
 			Network::Testnet => BitcoinCashConsensusParams {
 				height: 1155876,
 				difficulty_adjustion_height: 1188697,
+				monolith_height: ::std::u32::MAX, // TODO: change me
 			},
 			Network::Regtest | Network::Unitest => BitcoinCashConsensusParams {
 				height: 0,
 				difficulty_adjustion_height: 0,
+				monolith_height: ::std::u32::MAX, // TODO: change me
 			},
 		}
 	}

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -12,6 +12,7 @@ use synchronization_server::{Server, ServerTask};
 use synchronization_verifier::{TransactionVerificationSink};
 use primitives::hash::H256;
 use miner::BlockTemplate;
+use verification::median_timestamp_inclusive;
 use synchronization_peers::{TransactionAnnouncementType, BlockAnnouncementType};
 use types::{PeerIndex, RequestId, StorageRef, MemoryPoolRef, PeersRef, ExecutorRef,
 	ClientRef, ServerRef, SynchronizationStateRef, SyncListenerRef};
@@ -275,11 +276,14 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 
 	/// Get block template for mining
 	pub fn get_block_template(&self) -> BlockTemplate {
-		let height = self.storage.best_block().number;
-		let max_block_size = self.consensus.fork.max_block_size(height);
+		let previous_block_height = self.storage.best_block().number;
+		let previous_block_header = self.storage.block_header(previous_block_height.into()).expect("best block is in db; qed");
+		let median_timestamp = median_timestamp_inclusive(previous_block_header.hash(), self.storage.as_block_header_provider());
+		let new_block_height = previous_block_height + 1;
+		let max_block_size = self.consensus.fork.max_block_size(new_block_height, median_timestamp);
 		let block_assembler = BlockAssembler {
 			max_block_size: max_block_size as u32,
-			max_block_sigops: self.consensus.fork.max_block_sigops(height, max_block_size) as u32,
+			max_block_sigops: self.consensus.fork.max_block_sigops(new_block_height, max_block_size) as u32,
 		};
 		let memory_pool = &*self.memory_pool.read();
 		block_assembler.create_new_block(&self.storage, memory_pool, time::get_time().sec as u32, &self.consensus)

--- a/verification/src/accept_chain.rs
+++ b/verification/src/accept_chain.rs
@@ -17,13 +17,13 @@ pub struct ChainAcceptor<'a> {
 }
 
 impl<'a> ChainAcceptor<'a> {
-	pub fn new(store: &'a Store, consensus: &'a ConsensusParams, verification_level: VerificationLevel, block: CanonBlock<'a>, height: u32, deployments: &'a BlockDeployments) -> Self {
+	pub fn new(store: &'a Store, consensus: &'a ConsensusParams, verification_level: VerificationLevel, block: CanonBlock<'a>, height: u32, median_time_past: u32, deployments: &'a BlockDeployments) -> Self {
 		trace!(target: "verification", "Block verification {}", block.hash().to_reversed_str());
 		let output_store = DuplexTransactionOutputProvider::new(store.as_transaction_output_provider(), block.raw());
 		let headers = store.as_block_header_provider();
 
 		ChainAcceptor {
-			block: BlockAcceptor::new(store.as_transaction_output_provider(), consensus, block, height, deployments, headers),
+			block: BlockAcceptor::new(store.as_transaction_output_provider(), consensus, block, height, median_time_past, deployments, headers),
 			header: HeaderAcceptor::new(headers, consensus, block.header(), height, deployments),
 			transactions: block.transactions()
 				.into_iter()
@@ -37,6 +37,7 @@ impl<'a> ChainAcceptor<'a> {
 						block.hash(),
 						height,
 						block.header.raw.time,
+						median_time_past,
 						tx_index,
 						deployments,
 				))

--- a/verification/src/accept_transaction.rs
+++ b/verification/src/accept_transaction.rs
@@ -291,6 +291,7 @@ pub struct TransactionEval<'a> {
 	verify_dersig: bool,
 	verify_witness: bool,
 	verify_nulldummy: bool,
+	verify_monolith_opcodes: bool,
 	signature_version: SignatureVersion,
 }
 
@@ -311,6 +312,10 @@ impl<'a> TransactionEval<'a> {
 		};
 		let verify_locktime = height >= params.bip65_height;
 		let verify_dersig = height >= params.bip66_height;
+		let verify_monolith_opcodes = match params.fork {
+			ConsensusFork::BitcoinCash(ref fork) if height >= fork.monolith_height => true,
+			_ => false,
+		};
 		let signature_version = match params.fork {
 			ConsensusFork::BitcoinCash(ref fork) if height >= fork.height => SignatureVersion::ForkId,
 			ConsensusFork::NoFork | ConsensusFork::BitcoinCash(_) => SignatureVersion::Base,
@@ -331,6 +336,7 @@ impl<'a> TransactionEval<'a> {
 			verify_dersig: verify_dersig,
 			verify_witness: verify_witness,
 			verify_nulldummy: verify_nulldummy,
+			verify_monolith_opcodes: verify_monolith_opcodes,
 			signature_version: signature_version,
 		}
 	}
@@ -371,7 +377,16 @@ impl<'a> TransactionEval<'a> {
 				.verify_checksequence(self.verify_checksequence)
 				.verify_dersig(self.verify_dersig)
 				.verify_nulldummy(self.verify_nulldummy)
-				.verify_witness(self.verify_witness);
+				.verify_witness(self.verify_witness)
+				.verify_concat(self.verify_monolith_opcodes)
+				.verify_split(self.verify_monolith_opcodes)
+				.verify_and(self.verify_monolith_opcodes)
+				.verify_or(self.verify_monolith_opcodes)
+				.verify_xor(self.verify_monolith_opcodes)
+				.verify_div(self.verify_monolith_opcodes)
+				.verify_mod(self.verify_monolith_opcodes)
+				.verify_bin2num(self.verify_monolith_opcodes)
+				.verify_num2bin(self.verify_monolith_opcodes);
 
 			try!(verify_script(&input, &output, &script_witness, &flags, &checker, self.signature_version)
 				.map_err(|e| TransactionError::Signature(index, e)));

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -110,7 +110,7 @@ pub use verify_transaction::{TransactionVerifier, MemoryPoolTransactionVerifier}
 pub use chain_verifier::BackwardsCompatibleChainVerifier;
 pub use error::{Error, TransactionError};
 pub use sigops::transaction_sigops;
-pub use timestamp::median_timestamp;
+pub use timestamp::{median_timestamp, median_timestamp_inclusive};
 pub use work::{work_required, is_valid_proof_of_work, is_valid_proof_of_work_hash, block_reward_satoshi};
 pub use deployments::Deployments;
 

--- a/verification/src/work_bch.rs
+++ b/verification/src/work_bch.rs
@@ -217,6 +217,7 @@ mod tests {
 		let uahf_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCash(BitcoinCashConsensusParams {
 			height: 1000,
 			difficulty_adjustion_height: 0xffffffff,
+			monolith_time: 0xffffffff,
 		}));
 		let mut header_provider = MemoryBlockHeaderProvider::default();
 		header_provider.insert(BlockHeader {
@@ -269,6 +270,7 @@ mod tests {
 		let uahf_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCash(BitcoinCashConsensusParams {
 			height: 1000,
 			difficulty_adjustion_height: 0xffffffff,
+			monolith_time: 0xffffffff,
 		}));
 
 


### PR DESCRIPTION
closes #479 

This [commit](https://github.com/paritytech/parity-bitcoin/commit/70b08a7ca007d496e606a163422e3e5772d63695) may be reverted later, replacing `monolith_time` with `monolith_height` for both performance + code clarity.