### PR TITLE
Blocks && fully spent transactions pruning

### DIFF
--- a/db/src/block_chain_db.rs
+++ b/db/src/block_chain_db.rs
@@ -28,11 +28,23 @@ use storage::{
 const KEY_BEST_BLOCK_NUMBER: &'static str = "best_block_number";
 const KEY_BEST_BLOCK_HASH: &'static str = "best_block_hash";
 
-const MAX_FORK_ROUTE_PRESET: usize = 2048;
+const MAX_FORK_ROUTE_PRESET: u32 = 2048;
+
+/// Database pruning parameters.
+pub struct PruningParams {
+	/// Pruning depth (i.e. we're saving pruning_depth last blocks because we believe
+	/// that fork still can affect these blocks).
+	pub pruning_depth: u32,
+	/// Prune blocks that can not became a part of reorg process.
+	pub prune_ancient_blocks: bool,
+	/// Prune fully spent transactions that can not not became a part of reorg process.
+	pub prune_spent_transactions: bool,
+}
 
 pub struct BlockChainDatabase<T> where T: KeyValueDatabase {
 	best_block: RwLock<BestBlock>,
 	db: T,
+	pruning: PruningParams,
 }
 
 pub struct ForkChainDatabase<'a, T> where T: 'a + KeyValueDatabase {
@@ -91,6 +103,7 @@ impl<T> BlockChainDatabase<CacheDatabase<AutoFlushingOverlayDatabase<T>>> where 
 		BlockChainDatabase {
 			best_block: RwLock::new(best_block),
 			db: db,
+			pruning: Default::default(),
 		}
 	}
 }
@@ -115,7 +128,18 @@ impl<T> BlockChainDatabase<T> where T: KeyValueDatabase {
 		BlockChainDatabase {
 			best_block: RwLock::new(best_block),
 			db: db,
+			pruning: Default::default(),
 		}
+	}
+
+	pub fn set_pruning_params(&mut self, params: PruningParams) {
+		// 11 is the because we take 11 last headers to calculate MTP. This limit must be
+		// raised to at least MAX_FORK_ROUTE_PRESET and assert replaced with Err before
+		// passing control over this to cli
+		// right now it is 11 to speed up tests
+		assert!(params.pruning_depth >= 11);
+
+		self.pruning = params;
 	}
 
 	pub fn best_block(&self) -> BestBlock {
@@ -222,7 +246,8 @@ impl<T> BlockChainDatabase<T> where T: KeyValueDatabase {
 
 	/// Rollbacks single best block
 	fn rollback_best(&self) -> Result<H256, Error> {
-		let decanonized = match self.block(self.best_block.read().hash.clone().into()) {
+		let best_block: BestBlock = self.best_block.read().clone();
+		let decanonized = match self.block(best_block.hash.clone().into()) {
 			Some(block) => block,
 			None => return Ok(H256::default()),
 		};
@@ -233,12 +258,7 @@ impl<T> BlockChainDatabase<T> where T: KeyValueDatabase {
 		// all code currently works in assumption that origin of all blocks is one of:
 		// {CanonChain, SideChain, SideChainBecomingCanonChain}
 		let mut update = DBTransaction::new();
-		update.delete(Key::BlockHeader(decanonized_hash.clone()));
-		update.delete(Key::BlockTransactions(decanonized_hash.clone()));
-		for tx in decanonized.transactions.into_iter() {
-			update.delete(Key::Transaction(tx.hash()));
-		}
-
+		self.delete_canon_block(best_block.number, &mut update, true);
 		self.db.write(update).map_err(Error::DatabaseError)?;
 
 		Ok(self.best_block().hash)
@@ -302,6 +322,9 @@ impl<T> BlockChainDatabase<T> where T: KeyValueDatabase {
 				}
 			}
 		}
+
+		self.prune_ancient_blocks(&mut update, new_best_block.number);
+		self.prune_spent_transactions(&mut update, new_best_block.number, &modified_meta);
 
 		for (hash, meta) in modified_meta.into_iter() {
 			update.insert(KeyValue::TransactionMeta(hash, meta));
@@ -382,6 +405,87 @@ impl<T> BlockChainDatabase<T> where T: KeyValueDatabase {
 			BlockRef::Hash(h) => Some(h),
 		}
 	}
+
+	fn prune_ancient_blocks(&self, update: &mut DBTransaction, new_best_block_number: u32) {
+		// if blocks pruning is enabled, prune ancient blocks (i.e. blocks that are
+		// older than pruning_depth)
+		if !self.pruning.prune_ancient_blocks {
+			return;
+		}
+
+		// we are never pruning the genesis block
+		// we are saving last pruning_depth blocks
+		// we are only pruning blocks from canon chain (because there are currently no
+		//   way to find descendant blocks, except for the canon chain case)
+		if let Some(last_block_to_prune) = new_best_block_number.checked_sub(self.pruning.pruning_depth) {
+			for block_number in (1..last_block_to_prune + 1).rev() {
+				match self.delete_canon_block(block_number, update, false) {
+					true => trace!(target: "prune", "pruning canon block {} at {}", block_number, new_best_block_number),
+					false => break,
+				}
+			}
+		}
+	}
+
+	fn prune_spent_transactions(&self, update: &mut DBTransaction, new_best_block_number: u32, modified_meta: &HashMap<H256, TransactionMeta>) {
+		// if transaction pruning is enabled, prune fully spent transactions (TX1) when we are
+		// sure that last transaction TX2, making TX1 fully spent, is older than pruning_depth
+		if !self.pruning.prune_spent_transactions {
+			return;
+		}
+
+		// first, remember hashes of transactions that could be pruned in the future
+		let txs_to_prune: Vec<_> = modified_meta.iter()
+			.filter(|(_, m)| m.is_fully_spent())
+			.map(|(t, _)| t)
+			.collect();
+		if !txs_to_prune.is_empty() {
+			trace!(target: "prune", "seheduling pruning of {} fully spent transactions at {}",
+				txs_to_prune.len(), new_best_block_number + self.pruning.pruning_depth + 1);
+			update.insert(KeyValue::SpentTransactions(
+				new_best_block_number + self.pruning.pruning_depth + 1,
+				List::from(txs_to_prune.into_iter().cloned().collect())));
+		}
+
+		// and now remove transactions that have been scheduled for pruning pruning_depth blocks ago
+		let txs_to_prune = self.get(Key::SpentTransactions(new_best_block_number))
+			.and_then(Value::as_spent_transactions)
+			.map(List::into);
+		if let Some(txs_to_prune) = txs_to_prune {
+			trace!(target: "db", "pruning {} fully spent transactions at {}", txs_to_prune.len(), new_best_block_number);
+			trace!(target: "prune", "pruning {} fully spent transactions at {}", txs_to_prune.len(), new_best_block_number);
+			for tx_to_prune in txs_to_prune {
+				update.delete(Key::Transaction(tx_to_prune.clone()));
+				update.delete(Key::TransactionMeta(tx_to_prune));
+			}
+		}
+	}
+
+	fn delete_canon_block(&self, block_number: u32, update: &mut DBTransaction, leave_no_traces: bool) -> bool {
+		let block_hash = match self.block_hash(block_number) {
+			Some(block_hash) => block_hash,
+			None => return false,
+		};
+
+		if self.get(Key::BlockHeader(block_hash.clone())).is_none() {
+			return false;
+		}
+
+		update.delete(Key::BlockHeader(block_hash.clone()));
+		update.delete(Key::BlockTransactions(block_hash.clone()));
+		if leave_no_traces {
+			update.delete(Key::BlockHash(block_number));
+			update.delete(Key::BlockNumber(block_hash.clone()));
+
+			let block_transactions = self.block_transaction_hashes(block_hash.clone().into());
+			for tx_hash in block_transactions {
+				update.delete(Key::Transaction(tx_hash.clone()));
+				update.delete(Key::TransactionMeta(tx_hash));
+			}
+		}
+
+		true
+	}
 }
 
 impl<T> BlockHeaderProvider for BlockChainDatabase<T> where T: KeyValueDatabase {
@@ -397,7 +501,7 @@ impl<T> BlockHeaderProvider for BlockChainDatabase<T> where T: KeyValueDatabase 
 }
 
 impl<T> BlockProvider for BlockChainDatabase<T> where T: KeyValueDatabase {
-	fn block_number(&self, hash: &H256) -> Option<u32> {
+		fn block_number(&self, hash: &H256) -> Option<u32> {
 		self.get(Key::BlockNumber(hash.clone()))
 			.and_then(Value::as_block_number)
 	}
@@ -584,5 +688,15 @@ impl<T> ConfigStore for BlockChainDatabase<T> where T: KeyValueDatabase {
 		let mut update = DBTransaction::new();
 		update.insert(KeyValue::Configuration("consensus_fork", consensus_fork.as_bytes().into()));
 		self.db.write(update).map_err(Error::DatabaseError)
+	}
+}
+
+impl Default for PruningParams {
+	fn default() -> Self {
+		PruningParams {
+			pruning_depth: MAX_FORK_ROUTE_PRESET,
+			prune_ancient_blocks: false,
+			prune_spent_transactions: false,
+		}
 	}
 }

--- a/db/src/block_chain_db.rs
+++ b/db/src/block_chain_db.rs
@@ -501,7 +501,7 @@ impl<T> BlockHeaderProvider for BlockChainDatabase<T> where T: KeyValueDatabase 
 }
 
 impl<T> BlockProvider for BlockChainDatabase<T> where T: KeyValueDatabase {
-		fn block_number(&self, hash: &H256) -> Option<u32> {
+	fn block_number(&self, hash: &H256) -> Option<u32> {
 		self.get(Key::BlockNumber(hash.clone()))
 			.and_then(Value::as_block_number)
 	}

--- a/db/src/kv/memorydb.rs
+++ b/db/src/kv/memorydb.rs
@@ -19,6 +19,7 @@ struct InnerDatabase {
 	transaction_meta: HashMap<H256, KeyState<TransactionMeta>>,
 	block_number: HashMap<H256, KeyState<u32>>,
 	configuration: HashMap<&'static str, KeyState<Bytes>>,
+	spent_transactions: HashMap<u32, KeyState<List<H256>>>,
 }
 
 #[derive(Default, Debug)]
@@ -81,6 +82,7 @@ impl KeyValueDatabase for MemoryDatabase {
 					KeyValue::TransactionMeta(key, value) => { db.transaction_meta.insert(key, KeyState::Insert(value)); },
 					KeyValue::BlockNumber(key, value) => { db.block_number.insert(key, KeyState::Insert(value)); },
 					KeyValue::Configuration(key, value) => { db.configuration.insert(key, KeyState::Insert(value)); },
+					KeyValue::SpentTransactions(key, value) => { db.spent_transactions.insert(key, KeyState::Insert(value)); },
 				},
 				Operation::Delete(delete) => match delete {
 					Key::Meta(key) => { db.meta.insert(key, KeyState::Delete); }
@@ -91,6 +93,7 @@ impl KeyValueDatabase for MemoryDatabase {
 					Key::TransactionMeta(key) => { db.transaction_meta.insert(key, KeyState::Delete); }
 					Key::BlockNumber(key) => { db.block_number.insert(key, KeyState::Delete); }
 					Key::Configuration(key) => { db.configuration.insert(key, KeyState::Delete); }
+					Key::SpentTransactions(key) => { db.spent_transactions.insert(key, KeyState::Delete); },
 				}
 			}
 		}
@@ -108,6 +111,7 @@ impl KeyValueDatabase for MemoryDatabase {
 			Key::TransactionMeta(ref key) => db.transaction_meta.get(key).cloned().unwrap_or_default().map(Value::TransactionMeta),
 			Key::BlockNumber(ref key) => db.block_number.get(key).cloned().unwrap_or_default().map(Value::BlockNumber),
 			Key::Configuration(ref key) => db.configuration.get(key).cloned().unwrap_or_default().map(Value::Configuration),
+			Key::SpentTransactions(ref key) => db.spent_transactions.get(key).cloned().unwrap_or_default().map(Value::SpentTransactions),
 		};
 
 		Ok(result)

--- a/db/src/kv/transaction.rs
+++ b/db/src/kv/transaction.rs
@@ -13,6 +13,7 @@ pub const COL_TRANSACTIONS: u32 = 4;
 pub const COL_TRANSACTIONS_META: u32 = 5;
 pub const COL_BLOCK_NUMBERS: u32 = 6;
 pub const COL_CONFIGURATION: u32 = 7;
+pub const COL_SPENT_TRANSACTIONS: u32 = 8;
 
 #[derive(Debug)]
 pub enum Operation {
@@ -30,6 +31,7 @@ pub enum KeyValue {
 	TransactionMeta(H256, TransactionMeta),
 	BlockNumber(H256, u32),
 	Configuration(&'static str, Bytes),
+	SpentTransactions(u32, List<H256>),
 }
 
 #[derive(Debug)]
@@ -42,6 +44,7 @@ pub enum Key {
 	TransactionMeta(H256),
 	BlockNumber(H256),
 	Configuration(&'static str),
+	SpentTransactions(u32),
 }
 
 #[derive(Debug, Clone)]
@@ -54,6 +57,7 @@ pub enum Value {
 	TransactionMeta(TransactionMeta),
 	BlockNumber(u32),
 	Configuration(Bytes),
+	SpentTransactions(List<H256>),
 }
 
 impl Value {
@@ -67,6 +71,7 @@ impl Value {
 			Key::TransactionMeta(_) => deserialize(bytes).map(Value::TransactionMeta),
 			Key::BlockNumber(_) => deserialize(bytes).map(Value::BlockNumber),
 			Key::Configuration(_) => deserialize(bytes).map(Value::Configuration),
+			Key::SpentTransactions(_) => deserialize(bytes).map(Value::SpentTransactions),
 		}.map_err(|e| format!("{:?}", e))
 	}
 
@@ -122,6 +127,13 @@ impl Value {
 	pub fn as_configuration(self) -> Option<Bytes> {
 		match self {
 			Value::Configuration(bytes) => Some(bytes),
+			_ => None,
+		}
+	}
+
+	pub fn as_spent_transactions(self) -> Option<List<H256>> {
+		match self {
+			Value::SpentTransactions(list) => Some(list),
 			_ => None,
 		}
 	}
@@ -228,6 +240,7 @@ impl<'a> From<&'a KeyValue> for RawKeyValue {
 			KeyValue::TransactionMeta(ref key, ref value) => (COL_TRANSACTIONS_META, serialize(key), serialize(value)),
 			KeyValue::BlockNumber(ref key, ref value) => (COL_BLOCK_NUMBERS, serialize(key), serialize(value)),
 			KeyValue::Configuration(ref key, ref value) => (COL_CONFIGURATION, serialize(key), serialize(value)),
+			KeyValue::SpentTransactions(ref key, ref value) => (COL_SPENT_TRANSACTIONS, serialize(key), serialize(value)),
 		};
 
 		RawKeyValue {
@@ -263,6 +276,7 @@ impl<'a> From<&'a Key> for RawKey {
 			Key::TransactionMeta(ref key) => (COL_TRANSACTIONS_META, serialize(key)),
 			Key::BlockNumber(ref key) => (COL_BLOCK_NUMBERS, serialize(key)),
 			Key::Configuration(ref key) => (COL_CONFIGURATION, serialize(key)),
+			Key::SpentTransactions(ref key) => (COL_SPENT_TRANSACTIONS, serialize(key)),
 		};
 
 		RawKey {

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -14,5 +14,5 @@ extern crate storage;
 pub mod kv;
 mod block_chain_db;
 
-pub use block_chain_db::{BlockChainDatabase, ForkChainDatabase};
+pub use block_chain_db::{BlockChainDatabase, ForkChainDatabase, PruningParams};
 pub use primitives::{hash, bytes};

--- a/db/tests/blockchaindb.rs
+++ b/db/tests/blockchaindb.rs
@@ -4,8 +4,9 @@ extern crate db;
 extern crate test_data;
 
 use chain::IndexedBlock;
-use storage::{ForkChain, BlockProvider, SideChainOrigin};
-use db::BlockChainDatabase;
+use storage::{ForkChain, BlockProvider, BlockHeaderProvider, SideChainOrigin,
+	TransactionProvider, TransactionMetaProvider};
+use db::{BlockChainDatabase, PruningParams};
 use db::kv::{MemoryDatabase, SharedMemoryDatabase};
 
 #[test]
@@ -127,4 +128,153 @@ fn switch_to_simple_fork() {
 	assert_eq!(b2.hash(), &store.best_block().hash);
 	assert_eq!(store.best_block().hash, store.block_hash(2).unwrap());
 
+}
+
+#[test]
+fn ancient_blocks_are_pruned() {
+	let pruning_depth = 11;
+	let blocks = test_data::build_n_empty_blocks_from_genesis(pruning_depth + 2, 1);
+	let mut store = BlockChainDatabase::open(MemoryDatabase::default());
+	store.set_pruning_params(PruningParams {
+		pruning_depth,
+		prune_ancient_blocks: true,
+		prune_spent_transactions: false,
+	});
+
+	store.insert(test_data::genesis().into()).unwrap();
+	store.canonize(&test_data::genesis().hash()).unwrap();
+
+	// insert first pruning_depth-1 blocks
+	for i in 0..pruning_depth-1 {
+		store.insert(blocks[i as usize].clone().into()).unwrap();
+		store.canonize(&blocks[i as usize].hash()).unwrap();
+	}
+
+	// there are now pruning_depth blocks in the database
+	// no blocks are pruned until there are pruning_depth+1
+	// => check that nothing is missing
+	assert!((0..pruning_depth).all(|i| store.block_header(i.into()).is_some()));
+
+	// insert block# pruning_depth+1
+	store.insert(blocks[pruning_depth as usize - 1].clone().into()).unwrap();
+	store.canonize(&blocks[pruning_depth as usize - 1].hash()).unwrap();
+
+	// no blocks are pruned, because we never prune genesis block
+	assert!((0..pruning_depth + 1).all(|i| store.block_header(i.into()).is_some()));
+
+	// insert block# pruning_depth+2
+	store.insert(blocks[pruning_depth as usize].clone().into()).unwrap();
+	store.canonize(&blocks[pruning_depth as usize].hash()).unwrap();
+
+	// check that block#1 is pruned and nothing else is missed
+	assert!(store.block_header(1.into()).is_none());
+	assert!((0..pruning_depth + 2)
+		.filter(|i| *i != 1)
+		.all(|i| store.block_header(i.into()).is_some()));
+
+	// insert block# pruning_depth+3
+	store.insert(blocks[pruning_depth as usize + 1].clone().into()).unwrap();
+	store.canonize(&blocks[pruning_depth as usize + 1].hash()).unwrap();
+
+	// check that block#1 and block#2 are pruned and nothing else is missed
+	assert!(store.block_header(1.into()).is_none());
+	assert!(store.block_header(2.into()).is_none());
+	assert!((0..pruning_depth + 3)
+		.filter(|i| *i != 1 && *i != 2)
+		.all(|i| store.block_header(i.into()).is_some()));
+}
+
+#[test]
+fn spent_transactions_are_pruned() {
+	let pruning_depth = 11;
+	let mut store = BlockChainDatabase::open(MemoryDatabase::default());
+	store.set_pruning_params(PruningParams {
+		pruning_depth,
+		prune_ancient_blocks: false,
+		prune_spent_transactions: true,
+	});
+
+	// insert genesis
+	store.insert(test_data::genesis().into()).unwrap();
+	store.canonize(&test_data::genesis().hash()).unwrap();
+
+	// insert block with TX we're going to prune later
+	// genesis -> tx
+	let block_with_input_tx = test_data::block_builder()
+		.header().nonce(1).parent(test_data::genesis().hash()).build()
+		.transaction().coinbase().build()
+		.transaction()
+			.output().value(10).build()
+			.output().value(20).build()
+			.build()
+		.build();
+	let tx = block_with_input_tx.transactions[1].hash();
+
+	store.insert(block_with_input_tx.clone().into()).unwrap();
+	store.canonize(&block_with_input_tx.hash()).unwrap();
+
+	// now insert pruning_depth + 1 empty blocks and check that tx is not pruned
+	// genesis -> tx -> 2049 x empty blocks
+	let blocks = test_data::build_n_empty_blocks_from(pruning_depth + 1, 2, &block_with_input_tx.header());
+	for block in &blocks {
+		store.insert(block.clone().into()).unwrap();
+		store.canonize(&block.hash()).unwrap();
+	}
+	assert!(store.transaction(&tx).is_some());
+	assert!(store.transaction_meta(&tx).is_some());
+
+	// now insert block with tx, spending out1 of initial tx
+	// genesis -> tx -> 2049 x empty blocks -> spend1
+	let spending1 = test_data::block_builder()
+		.header().nonce(1).parent(blocks.last().unwrap().hash()).build()
+		.transaction().coinbase().build()
+		.transaction()
+			.input().hash(tx.clone()).index(0).build()
+			.output().value(10).build()
+			.build()
+		.build();
+	store.insert(spending1.clone().into()).unwrap();
+	store.canonize(&spending1.hash()).unwrap();
+
+	// now insert pruning_depth + 1 empty blocks and check that tx is not pruned
+	// genesis -> tx -> 2049 x empty -> spend1 -> 2049 x empty
+	let blocks = test_data::build_n_empty_blocks_from(pruning_depth + 1, 2, &spending1.header());
+	for block in &blocks {
+		store.insert(block.clone().into()).unwrap();
+		store.canonize(&block.hash()).unwrap();
+	}
+	assert!(store.transaction(&tx).is_some());
+	assert!(store.transaction_meta(&tx).is_some());
+
+	// now insert block with tx, spending out2 of initial tx
+	// genesis -> tx -> 2049 x empty -> spend1 -> 2049 x empty -> spend2
+	let spending2 = test_data::block_builder()
+		.header().nonce(1).parent(blocks.last().unwrap().hash()).build()
+		.transaction().coinbase().build()
+		.transaction()
+			.input().hash(tx.clone()).index(1).build()
+			.output().value(20).build()
+			.build()
+		.build();
+	store.insert(spending2.clone().into()).unwrap();
+	store.canonize(&spending2.hash()).unwrap();
+
+	// now insert pruning_depth empty blocks and check that tx is not pruned
+	// genesis -> tx -> 2049 x empty -> spend1 -> 2049 x empty -> spend2 -> 2048 empty
+	let blocks = test_data::build_n_empty_blocks_from(pruning_depth, 2, &spending2.header());
+	for block in &blocks {
+		store.insert(block.clone().into()).unwrap();
+		store.canonize(&block.hash()).unwrap();
+	}
+	assert!(store.transaction(&tx).is_some());
+	assert!(store.transaction_meta(&tx).is_some());
+
+	// and now insert last block && check that tx is pruned
+	let blocks = test_data::build_n_empty_blocks_from(1, 2, &blocks.last().unwrap().header());
+	for block in &blocks {
+		store.insert(block.clone().into()).unwrap();
+		store.canonize(&block.hash()).unwrap();
+	}
+	assert!(store.transaction(&tx).is_none());
+	assert!(store.transaction_meta(&tx).is_none());
 }

--- a/pbtc/cli.yml
+++ b/pbtc/cli.yml
@@ -95,6 +95,11 @@ args:
         help: Non-default verification-level is applied until a block with given hash is met.
         takes_value: true
         value_name: BLOCK
+    - prune-mode:
+        long: prune-mode
+        help: Sets the pruning mode to none (default), header (headers of ancient blocks are pruned), or full (fully spent transactions are pruned in addition to blocks headers).
+        takes_value: true
+        value_name: MODE
 subcommands:
     - import:
         about: Import blocks from a Bitcoin Core database.

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -1,5 +1,6 @@
 use std::net;
 use clap;
+use db;
 use storage;
 use message::Services;
 use network::{Network, ConsensusParams, ConsensusFork, BitcoinCashConsensusParams};
@@ -47,7 +48,20 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		None => None,
 	};
 
-	let db = open_db(&data_dir, db_cache);
+	let (prune_ancient_blocks, prune_spent_transactions) = match matches.value_of("prune-mode") {
+		Some(s) if s == "none" => (false, false),
+		Some(s) if s == "header" => (true, false),
+		Some(s) if s == "full" => (true, true),
+		Some(s) => return Err(format!("Invalid prune mode: {}", s)),
+		None => (false, false),
+	};
+
+	let pruning_params = db::PruningParams {
+		prune_ancient_blocks,
+		prune_spent_transactions,
+		..Default::default()
+	};
+	let db = open_db(&data_dir, db_cache, pruning_params);
 
 	let quiet = matches.is_present("quiet");
 	let network = match (matches.is_present("testnet"), matches.is_present("regtest")) {

--- a/pbtc/config.rs
+++ b/pbtc/config.rs
@@ -55,6 +55,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		Some(s) => return Err(format!("Invalid prune mode: {}", s)),
 		None => (false, false),
 	};
+	let is_pruning_active = prune_ancient_blocks || prune_spent_transactions;
 
 	let pruning_params = db::PruningParams {
 		prune_ancient_blocks,
@@ -132,7 +133,7 @@ pub fn parse(matches: &clap::ArgMatches) -> Result<Config, String> {
 		None => None,
 	};
 
-	let services = Services::default().with_network(true);
+	let services = Services::default().with_network(!is_pruning_active);
 	let services = match &consensus.fork {
 		&ConsensusFork::BitcoinCash(_) => services.with_bitcoin_cash(true),
 		&ConsensusFork::BitcoinCore => services.with_witness(true),

--- a/pbtc/util.rs
+++ b/pbtc/util.rs
@@ -7,12 +7,14 @@ use db;
 use config::Config;
 use chain::IndexedBlock;
 
-pub fn open_db(data_dir: &Option<String>, db_cache: usize) -> storage::SharedStore {
+pub fn open_db(data_dir: &Option<String>, db_cache: usize, pruning: db::PruningParams) -> storage::SharedStore {
 	let db_path = match *data_dir {
 		Some(ref data_dir) => custom_path(&data_dir, "db"),
 		None => app_dir(AppDataType::UserData, &APP_INFO, "db").expect("Failed to get app dir"),
 	};
-	Arc::new(db::BlockChainDatabase::open_at_path(db_path, db_cache).expect("Failed to open database"))
+	let mut db = db::BlockChainDatabase::open_at_path(db_path, db_cache).expect("Failed to open database");
+	db.set_pruning_params(pruning);
+	Arc::new(db)
 }
 
 pub fn node_table_path(cfg: &Config) -> PathBuf {

--- a/storage/src/block_provider.rs
+++ b/storage/src/block_provider.rs
@@ -23,9 +23,7 @@ pub trait BlockProvider: BlockHeaderProvider {
 	fn block(&self, block_ref: BlockRef) -> Option<Block>;
 
 	/// returns true if store contains given block
-	fn contains_block(&self, block_ref: BlockRef) -> bool {
-		self.block_header_bytes(block_ref).is_some()
-	}
+	fn contains_block(&self, block_ref: BlockRef) -> bool;
 
 	/// resolves list of block transactions by block reference (number/hash)
 	fn block_transaction_hashes(&self, block_ref: BlockRef) -> Vec<H256>;

--- a/sync/src/synchronization_chain.rs
+++ b/sync/src/synchronization_chain.rs
@@ -281,7 +281,10 @@ impl Chain {
 	pub fn block_state(&self, hash: &H256) -> BlockState {
 		match self.hash_chain.contains_in(hash) {
 			Some(queue_index) => BlockState::from_queue_index(queue_index),
-			None => if self.storage.contains_block(storage::BlockRef::Hash(hash.clone())) {
+			// because of pruning, the header might be missing from db
+			// because of side chains, the block number can be missing from db
+			// => use double check here to find if block is in the database
+			None => if self.storage.block_number(hash).is_some() || self.storage.contains_block(hash.clone().into()) {
 				BlockState::Stored
 			} else if self.dead_end_blocks.contains(hash) {
 				BlockState::DeadEnd

--- a/sync/src/synchronization_chain.rs
+++ b/sync/src/synchronization_chain.rs
@@ -272,10 +272,9 @@ impl Chain {
 
 	/// Get block header by hash
 	pub fn block_header_by_hash(&self, hash: &H256) -> Option<IndexedBlockHeader> {
-		if let Some(block) = self.storage.block(storage::BlockRef::Hash(hash.clone())) {
-			return Some(block.block_header.into());
-		}
-		self.headers_chain.by_hash(hash)
+		self.storage.block_header(hash.clone().into())
+			.map(Into::into)
+			.or_else(|| self.headers_chain.by_hash(hash))
 	}
 
 	/// Get block state


### PR DESCRIPTION
closes #472 

So the idea is:
1) to remove `BlockHeader` and `BlockTransactions` of ancient blocks (blocks from canon chain with age > 2048);
2) to remove `Transaction` and `TransactionMeta` of transaction, when block, spending the last utxo of this transaction became ancient.

`prune-mode` cli option can take 3 values now:
"none" - no pruning;
"header" - 1 from ^^^;
"full" - 1+2 from ^^^.

I'll leave one of chains (`--btc` or `--bch`) syncing to see the final db size && post it here.