### PR TITLE
Remove `doc` profile from Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,6 @@ panic = 'abort'
 [profile.test]
 debug = true
 
-[profile.doc]
-debug = true
-
 [[bin]]
 path = "pbtc/main.rs"
 name = "pbtc"


### PR DESCRIPTION
Cargo warns about it being unused.