### PR TITLE
BCH Nov2018 HF: OP_CHECKDATASIG + OP_CHECKDATASIGVERIFY

### DIFF
--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -3,9 +3,9 @@ use primitives::hash::H256;
 use primitives::compact::Compact;
 use chain::{OutPoint, TransactionOutput, IndexedTransaction};
 use storage::{SharedStore, TransactionOutputProvider};
-use network::ConsensusParams;
+use network::{ConsensusParams, TransactionOrdering};
 use memory_pool::{MemoryPool, OrderingStrategy, Entry};
-use verification::{work_required, block_reward_satoshi, transaction_sigops};
+use verification::{work_required, block_reward_satoshi, transaction_sigops, median_timestamp_inclusive};
 
 const BLOCK_VERSION: u32 = 0x20000000;
 const BLOCK_HEADER_SIZE: u32 = 4 + 32 + 32 + 4 + 4 + 4;
@@ -116,7 +116,9 @@ impl SizePolicy {
 
 /// Block assembler
 pub struct BlockAssembler {
+	/// Maximal block size.
 	pub max_block_size: u32,
+	/// Maximal # of sigops in the block.
 	pub max_block_sigops: u32,
 }
 
@@ -246,13 +248,28 @@ impl BlockAssembler {
 		let mut transactions = Vec::new();
 
 		let mempool_iter = mempool.iter(OrderingStrategy::ByTransactionScore);
-		let tx_iter = FittingTransactionsIterator::new(store.as_transaction_output_provider(), mempool_iter, self.max_block_size, self.max_block_sigops, height, time);
+		let tx_iter = FittingTransactionsIterator::new(
+			store.as_transaction_output_provider(),
+			mempool_iter,
+			self.max_block_size,
+			self.max_block_sigops,
+			height,
+			time);
 		for entry in tx_iter {
 			// miner_fee is i64, but we can safely cast it to u64
 			// memory pool should restrict miner fee to be positive
 			coinbase_value += entry.miner_fee as u64;
 			let tx = IndexedTransaction::new(entry.hash.clone(), entry.transaction.clone());
 			transactions.push(tx);
+		}
+
+		// sort block transactions
+		let median_time_past = median_timestamp_inclusive(previous_header_hash.clone(), store.as_block_header_provider());
+		match consensus.fork.transaction_ordering(median_time_past) {
+			TransactionOrdering::Canonical => transactions.sort_unstable_by(|tx1, tx2|
+				tx1.hash.cmp(&tx2.hash)),
+			// memory pool iter returns transactions in topological order
+			TransactionOrdering::Topological => (),
 		}
 
 		BlockTemplate {
@@ -271,7 +288,16 @@ impl BlockAssembler {
 
 #[cfg(test)]
 mod tests {
-	use super::{SizePolicy, NextStep};
+	extern crate test_data;
+
+	use std::sync::Arc;
+	use db::BlockChainDatabase;
+	use primitives::hash::H256;
+	use storage::SharedStore;
+	use network::{ConsensusParams, ConsensusFork, Network, BitcoinCashConsensusParams};
+	use memory_pool::MemoryPool;
+	use self::test_data::{ChainBuilder, TransactionBuilder};
+	use super::{BlockAssembler, SizePolicy, NextStep, BlockTemplate};
 
 	#[test]
 	fn test_size_policy() {
@@ -316,5 +342,42 @@ mod tests {
 	#[test]
 	fn test_fitting_transactions_iterator_locked_transaction() {
 		// TODO
+	}
+
+	#[test]
+	fn block_assembler_transaction_order() {
+		fn construct_block(consensus: ConsensusParams) -> (BlockTemplate, H256, H256) {
+			let chain = &mut ChainBuilder::new();
+			TransactionBuilder::with_default_input(0).set_output(30).store(chain)	// transaction0
+				.into_input(0).set_output(50).store(chain);							// transaction0 -> transaction1
+			let hash0 = chain.at(0).hash();
+			let hash1 = chain.at(1).hash();
+
+			let mut pool = MemoryPool::new();
+			let storage: SharedStore = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
+			pool.insert_verified(chain.at(0).into());
+			pool.insert_verified(chain.at(1).into());
+
+			(BlockAssembler {
+				max_block_size: 0xffffffff,
+				max_block_sigops: 0xffffffff,
+			}.create_new_block(&storage, &pool, 0, &consensus), hash0, hash1)
+		}
+
+		// when topological consensus is used
+		let topological_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCore);
+		let (block, hash0, hash1) = construct_block(topological_consensus);
+		assert!(hash1 < hash0);
+		assert_eq!(block.transactions[0].hash, hash0);
+		assert_eq!(block.transactions[1].hash, hash1);
+
+		// when canonocal consensus is used
+		let mut canonical_fork = BitcoinCashConsensusParams::new(Network::Mainnet);
+		canonical_fork.magnetic_anomaly_time = 0;
+		let canonical_consensus = ConsensusParams::new(Network::Mainnet, ConsensusFork::BitcoinCash(canonical_fork));
+		let (block, hash0, hash1) = construct_block(canonical_consensus);
+		assert!(hash1 < hash0);
+		assert_eq!(block.transactions[0].hash, hash1);
+		assert_eq!(block.transactions[1].hash, hash0);
 	}
 }

--- a/network/src/consensus.rs
+++ b/network/src/consensus.rs
@@ -41,6 +41,9 @@ pub struct BitcoinCashConsensusParams {
 	/// Time of monolith (aka May 2018) hardfork.
 	/// https://github.com/bitcoincashorg/spec/blob/4fbb0face661e293bcfafe1a2a4744dcca62e50d/may-2018-hardfork.md
 	pub monolith_time: u32,
+	/// Time of magnetic anomaly (aka Nov 2018) hardfork.
+	/// https://github.com/bitcoincashorg/bitcoincash.org/blob/f92f5412f2ed60273c229f68dd8703b6d5d09617/spec/2018-nov-upgrade.md
+	pub magnetic_anomaly_time: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -55,6 +58,17 @@ pub enum ConsensusFork {
 	/// UAHF Technical Specification - https://github.com/Bitcoin-UAHF/spec/blob/master/uahf-technical-spec.md
 	/// BUIP-HF Digest for replay protected signature verification across hard forks - https://github.com/Bitcoin-UAHF/spec/blob/master/replay-protected-sighash.md
 	BitcoinCash(BitcoinCashConsensusParams),
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Describes the ordering of transactions within single block.
+pub enum TransactionOrdering {
+	/// Topological tranasaction ordering: if tx TX2 depends on tx TX1,
+	/// it should come AFTER TX1 (not necessary **right** after it).
+	Topological,
+	/// Canonical transaction ordering: transactions are ordered by their
+	/// hash (in ascending order).
+	Canonical,
 }
 
 impl ConsensusParams {
@@ -225,6 +239,14 @@ impl ConsensusFork {
 				unreachable!("BitcoinCash has no SegWit; weight is only checked with SegWit activated; qed"),
 		}
 	}
+
+	pub fn transaction_ordering(&self, median_time_past: u32) -> TransactionOrdering {
+		match *self {
+			ConsensusFork::BitcoinCash(ref fork) if median_time_past >= fork.magnetic_anomaly_time
+				=> TransactionOrdering::Canonical,
+			_ => TransactionOrdering::Topological,
+		}
+	}
 }
 
 impl BitcoinCashConsensusParams {
@@ -234,16 +256,19 @@ impl BitcoinCashConsensusParams {
 				height: 478559,
 				difficulty_adjustion_height: 504031,
 				monolith_time: 1526400000,
+				magnetic_anomaly_time: 1542300000,
 			},
 			Network::Testnet => BitcoinCashConsensusParams {
 				height: 1155876,
 				difficulty_adjustion_height: 1188697,
 				monolith_time: 1526400000,
+				magnetic_anomaly_time: 1542300000,
 			},
 			Network::Regtest | Network::Unitest => BitcoinCashConsensusParams {
 				height: 0,
 				difficulty_adjustion_height: 0,
 				monolith_time: 1526400000,
+				magnetic_anomaly_time: 1542300000,
 			},
 		}
 	}

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -10,6 +10,6 @@ mod network;
 
 pub use primitives::{hash, compact};
 
-pub use consensus::{ConsensusParams, ConsensusFork, BitcoinCashConsensusParams};
+pub use consensus::{ConsensusParams, ConsensusFork, BitcoinCashConsensusParams, TransactionOrdering};
 pub use deployments::Deployment;
 pub use network::{Magic, Network};

--- a/script/src/error.rs
+++ b/script/src/error.rs
@@ -19,11 +19,13 @@ pub enum Error {
 	NumberNotMinimallyEncoded,
 	SigCount,
 	PubkeyCount,
+	InvalidOperandSize,
 
 	// Failed verify operations
 	Verify,
 	EqualVerify,
 	CheckSigVerify,
+	CheckDataSigVerify,
 	NumEqualVerify,
 
 	// Logical/Format/Canonical errors.
@@ -33,7 +35,6 @@ pub enum Error {
 	InvalidAltstackOperation,
 	UnbalancedConditional,
 	InvalidSplitRange,
-	InvalidBitwiseOperation,
 	DivisionByZero,
 	ImpossibleEncoding,
 
@@ -78,6 +79,7 @@ impl fmt::Display for Error {
 			Error::Verify => "Failed verify operation".fmt(f),
 			Error::EqualVerify => "Failed equal verify operation".fmt(f),
 			Error::CheckSigVerify => "Failed signature check".fmt(f),
+			Error::CheckDataSigVerify => "Failed data signature check".fmt(f),
 			Error::NumEqualVerify => "Failed num equal verify operation".fmt(f),
 			Error::SigCount => "Maximum number of signature exceeded".fmt(f),
 			Error::PubkeyCount => "Maximum number of pubkeys per multisig exceeded".fmt(f),
@@ -97,7 +99,7 @@ impl fmt::Display for Error {
 			Error::InvalidAltstackOperation => "Invalid altstack operation".fmt(f),
 			Error::UnbalancedConditional => "Unbalanced conditional".fmt(f),
 			Error::InvalidSplitRange => "Invalid OP_SPLIT range".fmt(f),
-			Error::InvalidBitwiseOperation => "Invalid bitwise operation (check length of inputs)".fmt(f),
+			Error::InvalidOperandSize => "Invalid operand size".fmt(f),
 			Error::DivisionByZero => "Invalid division operation".fmt(f),
 			Error::ImpossibleEncoding => "The requested encoding is impossible to satisfy".fmt(f),
 

--- a/script/src/flags.rs
+++ b/script/src/flags.rs
@@ -98,6 +98,9 @@ pub struct VerificationFlags {
 	///
 	/// This opcode replaces OP_LEFT => enabling both OP_NUM2BIN && OP_LEFT would be an error
 	pub verify_num2bin: bool,
+
+	/// Support OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY opcodes.
+	pub verify_checkdatasig: bool,
 }
 
 impl VerificationFlags {
@@ -183,6 +186,11 @@ impl VerificationFlags {
 
 	pub fn verify_num2bin(mut self, value: bool) -> Self {
 		self.verify_num2bin = value;
+		self
+	}
+
+	pub fn verify_checkdatasig(mut self, value: bool) -> Self {
+		self.verify_checkdatasig = value;
 		self
 	}
 }

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -1,6 +1,6 @@
 use std::{cmp, mem};
 use bytes::Bytes;
-use keys::{Signature, Public};
+use keys::{Message, Signature, Public};
 use chain::constants::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use crypto::{sha1, sha256, dhash160, dhash256, ripemd160};
 use sign::{SignatureVersion, Sighash};
@@ -30,6 +30,25 @@ fn check_signature(
 	let signature = script_sig.into();
 
 	checker.check_signature(&signature, &public, script_code, hash_type, version)
+}
+
+/// Helper function.
+fn verify_signature(
+	checker: &SignatureChecker,
+	signature: Vec<u8>,
+	public: Vec<u8>,
+	message: Message,
+) -> bool {
+	let public = match Public::from_slice(&public) {
+		Ok(public) => public,
+		_ => return false,
+	};
+
+	if signature.is_empty() {
+		return false;
+	}
+
+	checker.verify_signature(&signature.into(), &public, &message.into())
 }
 
 fn is_public_key(v: &[u8]) -> bool {
@@ -603,7 +622,7 @@ pub fn eval_script(
 				let mask_len = mask.len();
 				let value_to_update = stack.last_mut()?;
 				if mask_len != value_to_update.len() {
-					return Err(Error::InvalidBitwiseOperation);
+					return Err(Error::InvalidOperandSize);
 				}
 				for (byte_to_update, byte_mask) in (*value_to_update).iter_mut().zip(mask.iter()) {
 					*byte_to_update = *byte_to_update & byte_mask;
@@ -614,7 +633,7 @@ pub fn eval_script(
 				let mask_len = mask.len();
 				let value_to_update = stack.last_mut()?;
 				if mask_len != value_to_update.len() {
-					return Err(Error::InvalidBitwiseOperation);
+					return Err(Error::InvalidOperandSize);
 				}
 				for (byte_to_update, byte_mask) in (*value_to_update).iter_mut().zip(mask.iter()) {
 					*byte_to_update = *byte_to_update | byte_mask;
@@ -625,7 +644,7 @@ pub fn eval_script(
 				let mask_len = mask.len();
 				let value_to_update = stack.last_mut()?;
 				if mask_len != value_to_update.len() {
-					return Err(Error::InvalidBitwiseOperation);
+					return Err(Error::InvalidOperandSize);
 				}
 				for (byte_to_update, byte_mask) in (*value_to_update).iter_mut().zip(mask.iter()) {
 					*byte_to_update = *byte_to_update ^ byte_mask;
@@ -1116,6 +1135,39 @@ pub fn eval_script(
 			Opcode::OP_VERNOTIF => {
 				return Err(Error::DisabledOpcode(opcode));
 			},
+			Opcode::OP_CHECKDATASIG | Opcode::OP_CHECKDATASIGVERIFY if flags.verify_checkdatasig => {
+				let pubkey = stack.pop()?;
+				let message = stack.pop()?;
+				let signature = stack.pop()?;
+
+				if message.len() != 32 {
+					return Err(Error::InvalidOperandSize);
+				}
+
+				let message = message[0..32].into();
+
+				check_signature_encoding(&signature, flags, version)?;
+				check_pubkey_encoding(&pubkey, flags)?;
+
+				let signature: Vec<u8> = signature.into();
+				let success = verify_signature(checker, signature.into(), pubkey.into(), message);
+				match opcode {
+					Opcode::OP_CHECKDATASIG => {
+						if success {
+							stack.push(vec![1].into());
+						} else {
+							stack.push(vec![0].into());
+						}
+					},
+					Opcode::OP_CHECKDATASIGVERIFY if !success => {
+						return Err(Error::CheckDataSigVerify);
+					},
+					_ => {},
+				}
+			},
+			Opcode::OP_CHECKDATASIG | Opcode::OP_CHECKDATASIGVERIFY => {
+				return Err(Error::DisabledOpcode(opcode));
+			},
 		}
 
 		if stack.len() + altstack.len() > 1000 {
@@ -1139,6 +1191,7 @@ pub fn eval_script(
 mod tests {
 	use bytes::Bytes;
 	use chain::Transaction;
+	use keys::{KeyPair, Private, Message, Network};
 	use sign::SignatureVersion;
 	use script::MAX_SCRIPT_ELEMENT_SIZE;
 	use {
@@ -2245,7 +2298,6 @@ mod tests {
 
 	#[test]
 	fn test_script_with_forkid_signature() {
-		use keys::{KeyPair, Private, Network};
 		use sign::UnsignedTransactionInput;
 		use chain::{OutPoint, TransactionOutput};
 
@@ -3423,7 +3475,7 @@ mod tests {
 			.push_data(&[0x22])
 			.push_opcode(Opcode::OP_AND)
 			.into_script();
-		let result = Err(Error::InvalidBitwiseOperation);
+		let result = Err(Error::InvalidOperandSize);
 		basic_test_with_flags(&script, &VerificationFlags::default().verify_and(true), result,
 			vec![].into());
 	}
@@ -3459,7 +3511,7 @@ mod tests {
 			.push_data(&[0x22])
 			.push_opcode(Opcode::OP_OR)
 			.into_script();
-		let result = Err(Error::InvalidBitwiseOperation);
+		let result = Err(Error::InvalidOperandSize);
 		basic_test_with_flags(&script, &VerificationFlags::default().verify_or(true), result,
 			vec![].into());
 	}
@@ -3495,7 +3547,7 @@ mod tests {
 			.push_data(&[0x22])
 			.push_opcode(Opcode::OP_XOR)
 			.into_script();
-		let result = Err(Error::InvalidBitwiseOperation);
+		let result = Err(Error::InvalidOperandSize);
 		basic_test_with_flags(&script, &VerificationFlags::default().verify_xor(true), result,
 			vec![].into());
 	}
@@ -3842,5 +3894,161 @@ mod tests {
 			.verify_concat(true)
 			.verify_split(true);
 		basic_test_with_flags(&script, &flags, Ok(true), vec![vec![0x01].into()].into());
+	}
+
+	#[test]
+	fn checkdatasig_spec_tests() {
+		// official tests from:
+		// https://github.com/bitcoincashorg/bitcoincash.org/blob/0c6f91b0b713aae3bc6c9834b46e80e247ff5fab/spec/op_checkdatasig.md
+
+		let kp = KeyPair::from_private(Private { network: Network::Mainnet, secret: 1.into(), compressed: false, }).unwrap();
+		
+		let pubkey = kp.public().clone();
+		let message: Message = [42u8; 32].into();
+		let correct_signature = kp.private().sign(&message).unwrap();
+		let correct_signature_for_other_message = kp.private().sign(&[43u8; 32].into()).unwrap();
+		let mut correct_signature = correct_signature.to_vec();
+		let mut correct_signature_for_other_message = correct_signature_for_other_message.to_vec();
+		correct_signature.push(0x81);
+		correct_signature_for_other_message.push(0x81);
+
+		let correct_flags = VerificationFlags::default()
+			.verify_checkdatasig(true)
+			.verify_dersig(true)
+			.verify_strictenc(true);
+		let incorrect_flags = VerificationFlags::default().verify_checkdatasig(false);
+
+		let correct_signature_script = Builder::default()
+			.push_data(&*correct_signature)
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG fails if 15 November 2018 protocol upgrade is not yet activated.
+		basic_test_with_flags(&correct_signature_script, &incorrect_flags, Err(Error::DisabledOpcode(Opcode::OP_CHECKDATASIG)), vec![].into());
+
+		// <sig> <msg> OP_CHECKDATASIG fails if there are fewer than 3 items on stack.
+		let too_few_args_sig_script = Builder::default()
+			.push_data(&[1u8; 32])
+			.push_data(&*message)
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+		basic_test_with_flags(&too_few_args_sig_script, &correct_flags, Err(Error::InvalidStackOperation), vec![].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG fails if <pubKey> is not a validly encoded public key.
+		let incorrect_pubkey_script = Builder::default()
+			.push_data(&*correct_signature)
+			.push_data(&*message)
+			.push_data(&[77u8; 15])
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+		basic_test_with_flags(&incorrect_pubkey_script, &correct_flags, Err(Error::PubkeyType), vec![].into());
+
+		// assuming that check_signature_encoding correctness is proved by other tests:
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG fails if <sig> is not a validly encoded signature with strict DER encoding.
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG fails if signature <sig> is not empty and does not pass the Low S check.
+		let incorrectly_encoded_signature_script = Builder::default()
+			.push_data(&[0u8; 65])
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+		basic_test_with_flags(&incorrectly_encoded_signature_script, &correct_flags, Err(Error::SignatureDer), vec![].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG fails if signature <sig> is not empty and does not pass signature validation of <msg> and <pubKey>.
+		let incorrect_signature_script = Builder::default()
+			.push_data(&*correct_signature_for_other_message)
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+		basic_test_with_flags(&incorrect_signature_script, &correct_flags, Ok(false), vec![vec![0].into()].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG pops three elements and pushes false onto the stack if <sig> is an empty byte array.
+		let empty_signature_script = Builder::default()
+			.push_data(&[])
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIG)
+			.into_script();
+		basic_test_with_flags(&empty_signature_script, &correct_flags, Ok(false), vec![vec![0].into()].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIG pops three elements and pushes true onto the stack if <sig> is a valid signature of <msg> with respect to <pubKey>.
+		basic_test_with_flags(&correct_signature_script, &correct_flags, Ok(true), vec![vec![1].into()].into());
+	}
+
+	#[test]
+	fn checkdatasigverify_spec_tests() {
+		// official tests from:
+		// https://github.com/bitcoincashorg/bitcoincash.org/blob/0c6f91b0b713aae3bc6c9834b46e80e247ff5fab/spec/op_checkdatasig.md
+
+		let kp = KeyPair::from_private(Private { network: Network::Mainnet, secret: 1.into(), compressed: false, }).unwrap();
+		
+		let pubkey = kp.public().clone();
+		let message: Message = [42u8; 32].into();
+		let correct_signature = kp.private().sign(&message).unwrap();
+		let correct_signature_for_other_message = kp.private().sign(&[43u8; 32].into()).unwrap();
+		let mut correct_signature = correct_signature.to_vec();
+		let mut correct_signature_for_other_message = correct_signature_for_other_message.to_vec();
+		correct_signature.push(0x81);
+		correct_signature_for_other_message.push(0x81);
+
+		let correct_flags = VerificationFlags::default()
+			.verify_checkdatasig(true)
+			.verify_dersig(true)
+			.verify_strictenc(true);
+		let incorrect_flags = VerificationFlags::default().verify_checkdatasig(false);
+
+		let correct_signature_script = Builder::default()
+			.push_data(&*correct_signature)
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIGVERIFY)
+			.into_script();
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFY fails if 15 November 2018 protocol upgrade is not yet activated.
+		basic_test_with_flags(&correct_signature_script, &incorrect_flags, Err(Error::DisabledOpcode(Opcode::OP_CHECKDATASIGVERIFY)), vec![].into());
+
+		// <sig> <msg> OP_CHECKDATASIGVERIFY fails if there are fewer than 3 item on stack.
+		let too_few_args_sig_script = Builder::default()
+			.push_data(&[1u8; 32])
+			.push_data(&*message)
+			.push_opcode(Opcode::OP_CHECKDATASIGVERIFY)
+			.into_script();
+		basic_test_with_flags(&too_few_args_sig_script, &correct_flags, Err(Error::InvalidStackOperation), vec![].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFYfails if <pubKey> is not a validly encoded public key.
+		let incorrect_pubkey_script = Builder::default()
+			.push_data(&*correct_signature)
+			.push_data(&*message)
+			.push_data(&[77u8; 15])
+			.push_opcode(Opcode::OP_CHECKDATASIGVERIFY)
+			.into_script();
+		basic_test_with_flags(&incorrect_pubkey_script, &correct_flags, Err(Error::PubkeyType), vec![].into());
+
+		// assuming that check_signature_encoding correctness is proved by other tests:
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFY fails if <sig> is not a validly encoded signature with strict DER encoding.
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFY fails if signature <sig> is not empty and does not pass the Low S check.
+		let incorrectly_encoded_signature_script = Builder::default()
+			.push_data(&[0u8; 65])
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIGVERIFY)
+			.into_script();
+		basic_test_with_flags(&incorrectly_encoded_signature_script, &correct_flags, Err(Error::SignatureDer), vec![].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFY fails if <sig> is not a valid signature of <msg> with respect to <pubKey>.
+		let incorrect_signature_script = Builder::default()
+			.push_data(&*correct_signature_for_other_message)
+			.push_data(&*message)
+			.push_data(&*pubkey)
+			.push_opcode(Opcode::OP_CHECKDATASIGVERIFY)
+			.into_script();
+		basic_test_with_flags(&incorrect_signature_script, &correct_flags, Err(Error::CheckDataSigVerify), vec![].into());
+
+		// <sig> <msg> <pubKey> OP_CHECKDATASIGVERIFY pops the top three stack elements if <sig> is a valid signature of <msg> with respect to <pubKey>.
+		// Ok(false) means success here, because OP_CHECKDATASIGVERIFY leaves empty stack
+		basic_test_with_flags(&correct_signature_script, &correct_flags, Ok(false), vec![].into());
 	}
 }

--- a/script/src/opcode.rs
+++ b/script/src/opcode.rs
@@ -213,6 +213,10 @@ pub enum Opcode {
 	OP_NOP8 = 0xb7,
 	OP_NOP9 = 0xb8,
 	OP_NOP10 = 0xb9,
+
+	// BCH crypto
+	OP_CHECKDATASIG = 0xba,
+	OP_CHECKDATASIGVERIFY = 0xbb,
 }
 
 impl fmt::Display for Opcode {
@@ -430,6 +434,11 @@ impl Opcode {
 			0xb7 => Some(OP_NOP8),
 			0xb8 => Some(OP_NOP9),
 			0xb9 => Some(OP_NOP10),
+
+			// BCH crypto
+			0xba => Some(OP_CHECKDATASIG),
+			0xbb => Some(OP_CHECKDATASIGVERIFY),
+
 			_ => None,
 		}
 	}
@@ -688,5 +697,9 @@ mod tests {
 		assert_eq!(Opcode::OP_NOP8, Opcode::from_u8(Opcode::OP_NOP8 as u8).unwrap());
 		assert_eq!(Opcode::OP_NOP9, Opcode::from_u8(Opcode::OP_NOP9 as u8).unwrap());
 		assert_eq!(Opcode::OP_NOP10, Opcode::from_u8(Opcode::OP_NOP10 as u8).unwrap());
+	
+		// BCH crypto
+		assert_eq!(Opcode::OP_CHECKDATASIG, Opcode::from_u8(Opcode::OP_CHECKDATASIG as u8).unwrap());
+		assert_eq!(Opcode::OP_CHECKDATASIGVERIFY, Opcode::from_u8(Opcode::OP_CHECKDATASIGVERIFY as u8).unwrap());
 	}
 }

--- a/script/src/verify.rs
+++ b/script/src/verify.rs
@@ -1,4 +1,4 @@
-use keys::{Public, Signature};
+use keys::{Public, Signature, Message};
 use chain::constants::{
 	SEQUENCE_FINAL, SEQUENCE_LOCKTIME_DISABLE_FLAG,
 	SEQUENCE_LOCKTIME_MASK, SEQUENCE_LOCKTIME_TYPE_FLAG, LOCKTIME_THRESHOLD
@@ -8,6 +8,13 @@ use {Script, TransactionInputSigner, Num};
 
 /// Checks transaction signature
 pub trait SignatureChecker {
+	fn verify_signature(
+		&self,
+		signature: &Signature,
+		public: &Public,
+		hash: &Message,
+	) -> bool;
+
 	fn check_signature(
 		&self,
 		signature: &Signature,
@@ -25,6 +32,10 @@ pub trait SignatureChecker {
 pub struct NoopSignatureChecker;
 
 impl SignatureChecker for NoopSignatureChecker {
+	fn verify_signature(&self, signature: &Signature, public: &Public, hash: &Message) -> bool {
+		public.verify(hash, signature).unwrap_or(false)
+	}
+
 	fn check_signature(&self, _: &Signature, _: &Public, _: &Script, _: u32, _: SignatureVersion) -> bool {
 		false
 	}
@@ -46,6 +57,15 @@ pub struct TransactionSignatureChecker {
 }
 
 impl SignatureChecker for TransactionSignatureChecker {
+	fn verify_signature(
+		&self,
+		signature: &Signature,
+		public: &Public,
+		hash: &Message,
+	) -> bool {
+		public.verify(hash, signature).unwrap_or(false)
+	}
+
 	fn check_signature(
 		&self,
 		signature: &Signature,
@@ -55,7 +75,7 @@ impl SignatureChecker for TransactionSignatureChecker {
 		version: SignatureVersion
 	) -> bool {
 		let hash = self.signer.signature_hash(self.input_index, self.input_amount, script_code, version, sighashtype);
-		public.verify(&hash, signature).unwrap_or(false)
+		self.verify_signature(signature, public, &hash)
 	}
 
 	fn check_lock_time(&self, lock_time: Num) -> bool {

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -286,7 +286,7 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 			max_block_sigops: self.consensus.fork.max_block_sigops(new_block_height, max_block_size) as u32,
 		};
 		let memory_pool = &*self.memory_pool.read();
-		block_assembler.create_new_block(&self.storage, memory_pool, time::get_time().sec as u32, &self.consensus)
+		block_assembler.create_new_block(&self.storage, memory_pool, time::get_time().sec as u32, median_timestamp, &self.consensus)
 	}
 
 	/// Install synchronization events listener

--- a/verification/src/duplex_store.rs
+++ b/verification/src/duplex_store.rs
@@ -2,6 +2,7 @@
 //! require sophisticated (in more than one source) previous transaction lookups
 
 use chain::{OutPoint, TransactionOutput};
+use network::TransactionOrdering;
 use storage::TransactionOutputProvider;
 
 #[derive(Clone, Copy)]
@@ -39,5 +40,21 @@ impl TransactionOutputProvider for NoopStore {
 
 	fn is_spent(&self, _prevout: &OutPoint) -> bool {
 		false
+	}
+}
+
+/// Converts actual transaction index into transaction index to use in
+/// TransactionOutputProvider::transaction_output call.
+/// When topological ordering is used, we expect ascendant transaction (TX1)
+/// to come BEFORE descendant transaction (TX2) in the block, like this:
+/// [ ... TX1 ... TX2 ... ]
+/// When canonical ordering is used, transactions order within block is not
+/// relevant for this check and ascendant transaction (TX1) can come AFTER
+/// descendant, like this:
+/// [ ... TX2 ... TX1 ... ]
+pub fn transaction_index_for_output_check(ordering: TransactionOrdering, tx_idx: usize) -> usize {
+	match ordering {
+		TransactionOrdering::Topological => tx_idx,
+		TransactionOrdering::Canonical => ::std::usize::MAX,
 	}
 }

--- a/verification/src/error.rs
+++ b/verification/src/error.rs
@@ -57,6 +57,8 @@ pub enum Error {
 	WitnessMerkleCommitmentMismatch,
 	/// SegWit: unexpected witness
 	UnexpectedWitness,
+	/// Non-canonical tranasctions ordering within block
+	NonCanonicalTransactionOrdering,
 	/// Database error
 	Database(DBError),
 }

--- a/verification/src/verify_block.rs
+++ b/verification/src/verify_block.rs
@@ -163,7 +163,7 @@ impl<'a> BlockSigops<'a> {
 	fn check(&self) -> Result<(), Error> {
 		// We cannot know if bip16 is enabled at this point so we disable it.
 		let sigops = self.block.transactions.iter()
-			.map(|tx| transaction_sigops(&tx.raw, &NoopStore, false))
+			.map(|tx| transaction_sigops(&tx.raw, &NoopStore, false, false))
 			.sum::<usize>();
 
 		if sigops > self.max_sigops {

--- a/verification/src/verify_transaction.rs
+++ b/verification/src/verify_transaction.rs
@@ -186,7 +186,7 @@ impl<'a> TransactionSigops<'a> {
 	}
 
 	fn check(&self) -> Result<(), TransactionError> {
-		let sigops = transaction_sigops(&self.transaction.raw, &NoopStore, false);
+		let sigops = transaction_sigops(&self.transaction.raw, &NoopStore, false, false);
 		if sigops > self.max_sigops {
 			Err(TransactionError::MaxSigops)
 		} else {

--- a/verification/src/work_bch.rs
+++ b/verification/src/work_bch.rs
@@ -141,7 +141,7 @@ fn work_required_bitcoin_cash_adjusted(parent_header: IndexedBlockHeader, time: 
 	// If the new block's timestamp is more than 2 * 10 minutes then allow
 	// mining of a min-difficulty block.
 	let max_bits = consensus.network.max_bits();
-	if consensus.network == Network::Testnet {
+	if consensus.network == Network::Testnet || consensus.network == Network::Unitest {
 		let max_time_gap = parent_header.raw.time + DOUBLE_SPACING_SECONDS;
 		if time > max_time_gap {
 			return max_bits.into();
@@ -218,6 +218,7 @@ mod tests {
 			height: 1000,
 			difficulty_adjustion_height: 0xffffffff,
 			monolith_time: 0xffffffff,
+			magnetic_anomaly_time: 0xffffffff,
 		}));
 		let mut header_provider = MemoryBlockHeaderProvider::default();
 		header_provider.insert(BlockHeader {
@@ -271,6 +272,7 @@ mod tests {
 			height: 1000,
 			difficulty_adjustion_height: 0xffffffff,
 			monolith_time: 0xffffffff,
+			magnetic_anomaly_time: 0xffffffff,
 		}));
 
 


### PR DESCRIPTION
on top of #524 
these commits only: https://github.com/paritytech/parity-bitcoin/commit/ad4f51ac07369c6b0659c1f60d8dd5e5b129ae48 + https://github.com/paritytech/parity-bitcoin/pull/525/commits/cc823839a6228eef63efe0b2b259b7f4ea12e0a6
part of #519 

This PR introduces two new opcodes (`OP_CHECKDATASIG` + `OP_CHECKDATASIGVERIFY`) that are enabled in post-HF BCH scripts.