### PR TITLE
Remove dyn trait warnings

### DIFF
--- a/db/src/block_chain_db.rs
+++ b/db/src/block_chain_db.rs
@@ -40,7 +40,7 @@ pub struct ForkChainDatabase<'a, T> where T: 'a + KeyValueDatabase {
 }
 
 impl<'a, T> ForkChain for ForkChainDatabase<'a, T> where T: KeyValueDatabase {
-	fn store(&self) -> &Store {
+	fn store(&self) -> &dyn Store {
 		&self.blockchain
 	}
 
@@ -530,15 +530,15 @@ impl<T> BlockChain for BlockChainDatabase<T> where T: KeyValueDatabase {
 }
 
 impl<T> Forkable for BlockChainDatabase<T> where T: KeyValueDatabase {
-	fn fork<'a>(&'a self, side_chain: SideChainOrigin) -> Result<Box<ForkChain + 'a>, Error> {
+	fn fork<'a>(&'a self, side_chain: SideChainOrigin) -> Result<Box<dyn ForkChain + 'a>, Error> {
 		BlockChainDatabase::fork(self, side_chain)
 			.map(|fork_chain| {
-				let boxed: Box<ForkChain> = Box::new(fork_chain);
+				let boxed: Box<dyn ForkChain> = Box::new(fork_chain);
 				boxed
 			})
 	}
 
-	fn switch_to_fork<'a>(&self, fork: Box<ForkChain + 'a>) -> Result<(), Error> {
+	fn switch_to_fork<'a>(&self, fork: Box<dyn ForkChain + 'a>) -> Result<(), Error> {
 		let mut best_block = self.best_block.write();
 		*best_block = fork.store().best_block();
 		fork.flush()
@@ -546,7 +546,7 @@ impl<T> Forkable for BlockChainDatabase<T> where T: KeyValueDatabase {
 }
 
 impl<T> CanonStore for BlockChainDatabase<T> where T: KeyValueDatabase {
-	fn as_store(&self) -> &Store {
+	fn as_store(&self) -> &dyn Store {
 		&*self
 	}
 }

--- a/import/src/blk.rs
+++ b/import/src/blk.rs
@@ -44,7 +44,7 @@ pub fn open_blk_dir<P>(path: P) -> Result<BlkDir, io::Error> where P: AsRef<path
 
 /// Bitcoind database blocks iterator
 pub struct BlkDir {
-	iter: Box<Iterator<Item = Result<Block, ReaderError>>>,
+	iter: Box<dyn Iterator<Item = Result<Block, ReaderError>>>,
 }
 
 impl Iterator for BlkDir {

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -125,7 +125,7 @@ pub struct BlockAssembler {
 /// Iterator iterating over mempool transactions and yielding only those which fit the block
 struct FittingTransactionsIterator<'a, T> {
 	/// Shared store is used to query previous transaction outputs from database
-	store: &'a TransactionOutputProvider,
+	store: &'a dyn TransactionOutputProvider,
 	/// Memory pool transactions iterator
 	iter: T,
 	/// New block height
@@ -148,7 +148,7 @@ struct FittingTransactionsIterator<'a, T> {
 
 impl<'a, T> FittingTransactionsIterator<'a, T> where T: Iterator<Item = &'a Entry> {
 	fn new(
-		store: &'a TransactionOutputProvider,
+		store: &'a dyn TransactionOutputProvider,
 		iter: T,
 		max_block_size: u32,
 		max_block_sigops: u32,

--- a/miner/src/fee.rs
+++ b/miner/src/fee.rs
@@ -10,7 +10,7 @@ pub trait MemoryPoolFeeCalculator {
 }
 
 /// Fee calculator that computes sum of real transparent fee + real shielded fee.
-pub struct FeeCalculator<'a>(pub &'a TransactionOutputProvider);
+pub struct FeeCalculator<'a>(pub &'a dyn TransactionOutputProvider);
 
 impl<'a> MemoryPoolFeeCalculator for FeeCalculator<'a> {
 	fn calculate(&self, memory_pool: &MemoryPool, tx: &Transaction) -> u64 {
@@ -32,7 +32,7 @@ impl MemoryPoolFeeCalculator for NonZeroFeeCalculator {
 	}
 }
 
-pub fn transaction_fee(store: &TransactionOutputProvider, tx: &Transaction) -> u64 {
+pub fn transaction_fee(store: &dyn TransactionOutputProvider, tx: &Transaction) -> u64 {
 	let input_value = tx.inputs.iter().fold(0, |acc, input| acc + store
 		.transaction_output(&input.previous_output, ::std::usize::MAX)
 		.map(|output| output.value)
@@ -42,7 +42,7 @@ pub fn transaction_fee(store: &TransactionOutputProvider, tx: &Transaction) -> u
 	input_value.saturating_sub(output_value)
 }
 
-pub fn transaction_fee_rate(store: &TransactionOutputProvider, tx: &Transaction) -> u64 {
+pub fn transaction_fee_rate(store: &dyn TransactionOutputProvider, tx: &Transaction) -> u64 {
 	transaction_fee(store, tx) / tx.serialized_size() as u64
 }
 

--- a/p2p/src/io/deadline.rs
+++ b/p2p/src/io/deadline.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use futures::{Future, Select, Poll, Async};
 use tokio_core::reactor::{Handle, Timeout};
 
-type DeadlineBox<F> = Box<Future<Item = DeadlineStatus<<F as Future>::Item>, Error = <F as Future>::Error> + Send>;
+type DeadlineBox<F> = Box<dyn Future<Item = DeadlineStatus<<F as Future>::Item>, Error = <F as Future>::Error> + Send>;
 
 pub fn deadline<F, T>(duration: Duration, handle: &Handle, future: F) -> Result<Deadline<F>, io::Error>
 	where F: Future<Item = T, Error = io::Error> + Send + 'static, T: 'static {

--- a/p2p/src/protocol/mod.rs
+++ b/p2p/src/protocol/mod.rs
@@ -29,7 +29,7 @@ pub trait Protocol: Send {
 	fn on_close(&mut self) {}
 
 	/// Boxes the protocol.
-	fn boxed(self) -> Box<Protocol> where Self: Sized + 'static {
+	fn boxed(self) -> Box<dyn Protocol> where Self: Sized + 'static {
 		Box::new(self)
 	}
 }

--- a/p2p/src/protocol/sync.rs
+++ b/p2p/src/protocol/sync.rs
@@ -5,10 +5,10 @@ use protocol::Protocol;
 use net::PeerContext;
 use ser::SERIALIZE_TRANSACTION_WITNESS;
 
-pub type InboundSyncConnectionRef = Box<InboundSyncConnection>;
-pub type OutboundSyncConnectionRef = Arc<OutboundSyncConnection>;
-pub type LocalSyncNodeRef = Box<LocalSyncNode>;
-pub type InboundSyncConnectionStateRef = Arc<InboundSyncConnectionState>;
+pub type InboundSyncConnectionRef = Box<dyn InboundSyncConnection>;
+pub type OutboundSyncConnectionRef = Arc<dyn OutboundSyncConnection>;
+pub type LocalSyncNodeRef = Box<dyn LocalSyncNode>;
+pub type InboundSyncConnectionStateRef = Arc<dyn InboundSyncConnectionState>;
 
 pub trait LocalSyncNode : Send + Sync {
 	fn create_sync_session(&self, height: i32, services: Services, outbound: OutboundSyncConnectionRef) -> InboundSyncConnectionRef;

--- a/p2p/src/session.rs
+++ b/p2p/src/session.rs
@@ -37,11 +37,11 @@ impl SessionFactory for NormalSessionFactory {
 
 pub struct Session {
 	peer_context: Arc<PeerContext>,
-	protocols: Mutex<Vec<Box<Protocol>>>,
+	protocols: Mutex<Vec<Box<dyn Protocol>>>,
 }
 
 impl Session {
-	pub fn new(peer_context: Arc<PeerContext>, protocols: Vec<Box<Protocol>>) -> Self {
+	pub fn new(peer_context: Arc<PeerContext>, protocols: Vec<Box<dyn Protocol>>) -> Self {
 		Session {
 			peer_context: peer_context,
 			protocols: Mutex::new(protocols),

--- a/script/src/interpreter.rs
+++ b/script/src/interpreter.rs
@@ -11,7 +11,7 @@ use {
 
 /// Helper function.
 fn check_signature(
-	checker: &SignatureChecker,
+	checker: &dyn SignatureChecker,
 	mut script_sig: Vec<u8>,
 	public: Vec<u8>,
 	script_code: &Script,
@@ -34,7 +34,7 @@ fn check_signature(
 
 /// Helper function.
 fn verify_signature(
-	checker: &SignatureChecker,
+	checker: &dyn SignatureChecker,
 	signature: Vec<u8>,
 	public: Vec<u8>,
 	message: Message,
@@ -266,7 +266,7 @@ pub fn verify_script(
 	script_pubkey: &Script,
 	witness: &ScriptWitness,
 	flags: &VerificationFlags,
-	checker: &SignatureChecker,
+	checker: &dyn SignatureChecker,
 	version: SignatureVersion,
 ) -> Result<(), Error> {
 	if flags.verify_sigpushonly && !script_sig.is_push_only() {
@@ -369,7 +369,7 @@ fn verify_witness_program(
 	witness_version: u8,
 	witness_program: &[u8],
 	flags: &VerificationFlags,
-	checker: &SignatureChecker,
+	checker: &dyn SignatureChecker,
 ) -> Result<bool, Error> {
 	if witness_version != 0 {
 		if flags.verify_discourage_upgradable_witness_program {
@@ -437,7 +437,7 @@ pub fn eval_script(
 	stack: &mut Stack<Bytes>,
 	script: &Script,
 	flags: &VerificationFlags,
-	checker: &SignatureChecker,
+	checker: &dyn SignatureChecker,
 	version: SignatureVersion
 ) -> Result<bool, Error> {
 	if script.len() > script::MAX_SCRIPT_SIZE {
@@ -608,7 +608,7 @@ pub fn eval_script(
 				}
 				let n: usize = n.into();
 				let splitted_value = {
-					let mut value_to_split = stack.last_mut()?;
+					let value_to_split = stack.last_mut()?;
 					if n > value_to_split.len() {
 						return Err(Error::InvalidSplitRange);
 					}
@@ -3897,7 +3897,7 @@ mod tests {
 		// https://github.com/bitcoincashorg/bitcoincash.org/blob/0c6f91b0b713aae3bc6c9834b46e80e247ff5fab/spec/op_checkdatasig.md
 
 		let kp = KeyPair::from_private(Private { network: Network::Mainnet, secret: 1.into(), compressed: false, }).unwrap();
-		
+
 		let pubkey = kp.public().clone();
 		let message = vec![42u8; 32];
 		let correct_signature = kp.private().sign(&Message::from(sha256(&message))).unwrap();
@@ -3979,7 +3979,7 @@ mod tests {
 		// https://github.com/bitcoincashorg/bitcoincash.org/blob/0c6f91b0b713aae3bc6c9834b46e80e247ff5fab/spec/op_checkdatasig.md
 
 		let kp = KeyPair::from_private(Private { network: Network::Mainnet, secret: 1.into(), compressed: false, }).unwrap();
-		
+
 		let pubkey = kp.public().clone();
 		let message = vec![42u8; 32];
 		let correct_signature = kp.private().sign(&Message::from(sha256(&message))).unwrap();

--- a/serialization/src/compact_integer.rs
+++ b/serialization/src/compact_integer.rs
@@ -61,15 +61,15 @@ impl From<u64> for CompactInteger {
 impl Serializable for CompactInteger {
 	fn serialize(&self, stream: &mut Stream) {
 		match self.0 {
-			0...0xfc => {
+			0..=0xfc => {
 				stream.append(&(self.0 as u8));
 			},
-			0xfd...0xffff => {
+			0xfd..=0xffff => {
 				stream
 					.append(&0xfdu8)
 					.append(&(self.0 as u16));
 			},
-			0x10000...0xffff_ffff => {
+			0x10000..=0xffff_ffff => {
 				stream
 					.append(&0xfeu8)
 					.append(&(self.0 as u32));
@@ -84,9 +84,9 @@ impl Serializable for CompactInteger {
 
 	fn serialized_size(&self) -> usize {
 		match self.0 {
-			0...0xfc => 1,
-			0xfd...0xffff => 3,
-			0x10000...0xffff_ffff => 5,
+			0..=0xfc => 1,
+			0xfd..=0xffff => 3,
+			0x10000..=0xffff_ffff => 5,
 			_ => 9,
 		}
 	}
@@ -95,7 +95,7 @@ impl Serializable for CompactInteger {
 impl Deserializable for CompactInteger {
 	fn deserialize<T>(reader: &mut Reader<T>) -> Result<Self, ReaderError> where T: io::Read {
 		let result = match try!(reader.read::<u8>()) {
-			i @ 0...0xfc => i.into(),
+			i @ 0..=0xfc => i.into(),
 			0xfd => try!(reader.read::<u16>()).into(),
 			0xfe => try!(reader.read::<u32>()).into(),
 			_ => try!(reader.read::<u64>()).into(),

--- a/serialization/src/reader.rs
+++ b/serialization/src/reader.rs
@@ -89,7 +89,7 @@ impl<R> Reader<R> where R: io::Read {
 		T::deserialize(&mut reader)
 	}
 
-	pub fn skip_while(&mut self, predicate: &Fn(u8) -> bool) -> Result<(), Error> {
+	pub fn skip_while(&mut self, predicate: &dyn Fn(u8) -> bool) -> Result<(), Error> {
 		let mut next_buffer = [0u8];
 		loop {
 			let next = match self.peeked.take() {

--- a/storage/src/block_ancestors.rs
+++ b/storage/src/block_ancestors.rs
@@ -3,11 +3,11 @@ use {BlockRef, BlockHeaderProvider};
 
 pub struct BlockAncestors<'a> {
 	block: Option<BlockRef>,
-	headers: &'a BlockHeaderProvider,
+	headers: &'a dyn BlockHeaderProvider,
 }
 
 impl<'a> BlockAncestors<'a> {
-	pub fn new(block: BlockRef, headers: &'a BlockHeaderProvider) -> Self {
+	pub fn new(block: BlockRef, headers: &'a dyn BlockHeaderProvider) -> Self {
 		BlockAncestors {
 			block: Some(block),
 			headers: headers,

--- a/storage/src/block_chain.rs
+++ b/storage/src/block_chain.rs
@@ -4,7 +4,7 @@ use {Error, BlockOrigin, Store, SideChainOrigin};
 
 pub trait ForkChain {
 	/// Returns forks underlaying store.
-	fn store(&self) -> &Store;
+	fn store(&self) -> &dyn Store;
 
 	/// Flush fork changes to canon chain.
 	/// Should not be used directly from outside of `BlockChain`.
@@ -31,9 +31,9 @@ pub trait BlockChain {
 pub trait Forkable {
 	/// Forks current blockchain.
 	/// Lifetime guarantees fork relationship with canon chain.
-	fn fork<'a>(&'a self, side_chain: SideChainOrigin) -> Result<Box<ForkChain + 'a>, Error>;
+	fn fork<'a>(&'a self, side_chain: SideChainOrigin) -> Result<Box<dyn ForkChain + 'a>, Error>;
 
 	/// Switches blockchain to given fork.
 	/// Lifetime guarantees that fork comes from this canon chain.
-	fn switch_to_fork<'a>(&'a self, fork: Box<ForkChain + 'a>) -> Result<(), Error>;
+	fn switch_to_fork<'a>(&'a self, fork: Box<dyn ForkChain + 'a>) -> Result<(), Error>;
 }

--- a/storage/src/block_iterator.rs
+++ b/storage/src/block_iterator.rs
@@ -4,11 +4,11 @@ use {BlockRef, BlockHeaderProvider};
 pub struct BlockIterator<'a> {
 	block: u32,
 	period: u32,
-	headers: &'a BlockHeaderProvider,
+	headers: &'a dyn BlockHeaderProvider,
 }
 
 impl<'a> BlockIterator<'a> {
-	pub fn new(block: u32, period: u32, headers: &'a BlockHeaderProvider) -> Self {
+	pub fn new(block: u32, period: u32, headers: &'a dyn BlockHeaderProvider) -> Self {
 		BlockIterator {
 			block: block,
 			period: period,

--- a/storage/src/duplex_store.rs
+++ b/storage/src/duplex_store.rs
@@ -7,12 +7,12 @@ use TransactionOutputProvider;
 
 #[derive(Clone, Copy)]
 pub struct DuplexTransactionOutputProvider<'a> {
-	first: &'a TransactionOutputProvider,
-	second: &'a TransactionOutputProvider,
+	first: &'a dyn TransactionOutputProvider,
+	second: &'a dyn TransactionOutputProvider,
 }
 
 impl<'a> DuplexTransactionOutputProvider<'a> {
-	pub fn new(first: &'a TransactionOutputProvider, second: &'a TransactionOutputProvider) -> Self {
+	pub fn new(first: &'a dyn TransactionOutputProvider, second: &'a dyn TransactionOutputProvider) -> Self {
 		DuplexTransactionOutputProvider {
 			first: first,
 			second: second,

--- a/storage/src/store.rs
+++ b/storage/src/store.rs
@@ -6,7 +6,7 @@ use {
 };
 
 pub trait CanonStore: Store + Forkable + ConfigStore {
-	fn as_store(&self) -> &Store;
+	fn as_store(&self) -> &dyn Store;
 }
 
 /// Configuration storage interface
@@ -32,37 +32,37 @@ pub trait Store: AsSubstore {
 
 /// Allows casting Arc<Store> to reference to any substore type
 pub trait AsSubstore: BlockChain + BlockProvider + TransactionProvider + TransactionMetaProvider + TransactionOutputProvider {
-	fn as_block_provider(&self) -> &BlockProvider;
+	fn as_block_provider(&self) -> &dyn BlockProvider;
 
-	fn as_block_header_provider(&self) -> &BlockHeaderProvider;
+	fn as_block_header_provider(&self) -> &dyn BlockHeaderProvider;
 
-	fn as_transaction_provider(&self) -> &TransactionProvider;
+	fn as_transaction_provider(&self) -> &dyn TransactionProvider;
 
-	fn as_transaction_output_provider(&self) -> &TransactionOutputProvider;
+	fn as_transaction_output_provider(&self) -> &dyn TransactionOutputProvider;
 
-	fn as_transaction_meta_provider(&self) -> &TransactionMetaProvider;
+	fn as_transaction_meta_provider(&self) -> &dyn TransactionMetaProvider;
 }
 
 impl<T> AsSubstore for T where T: BlockChain + BlockProvider + TransactionProvider + TransactionMetaProvider + TransactionOutputProvider {
-	fn as_block_provider(&self) -> &BlockProvider {
+	fn as_block_provider(&self) -> &dyn BlockProvider {
 		&*self
 	}
 
-	fn as_block_header_provider(&self) -> &BlockHeaderProvider {
+	fn as_block_header_provider(&self) -> &dyn BlockHeaderProvider {
 		&*self
 	}
 
-	fn as_transaction_provider(&self) -> &TransactionProvider {
+	fn as_transaction_provider(&self) -> &dyn TransactionProvider {
 		&*self
 	}
 
-	fn as_transaction_output_provider(&self) -> &TransactionOutputProvider {
+	fn as_transaction_output_provider(&self) -> &dyn TransactionOutputProvider {
 		&*self
 	}
 
-	fn as_transaction_meta_provider(&self) -> &TransactionMetaProvider {
+	fn as_transaction_meta_provider(&self) -> &dyn TransactionMetaProvider {
 		&*self
 	}
 }
 
-pub type SharedStore = Arc<CanonStore + Send + Sync>;
+pub type SharedStore = Arc<dyn CanonStore + Send + Sync>;

--- a/storage/src/transaction_provider.rs
+++ b/storage/src/transaction_provider.rs
@@ -40,13 +40,13 @@ pub trait TransactionMetaProvider: Send + Sync {
 /// Not intended for long-lasting life, because it never clears its internal
 /// cache. The backing storage is considered readonly for the cache lifetime.
 pub struct CachedTransactionOutputProvider<'a> {
-	backend: &'a TransactionOutputProvider,
+	backend: &'a dyn TransactionOutputProvider,
 	cached_outputs: RwLock<HashMap<OutPoint, Option<TransactionOutput>>>,
 }
 
 impl<'a> CachedTransactionOutputProvider<'a> {
 	/// Create new cached tx output provider backed by passed provider.
-	pub fn new(backend: &'a TransactionOutputProvider) -> Self {
+	pub fn new(backend: &'a dyn TransactionOutputProvider) -> Self {
 		CachedTransactionOutputProvider {
 			backend,
 			cached_outputs: RwLock::new(HashMap::new()),

--- a/sync/src/synchronization_client.rs
+++ b/sync/src/synchronization_client.rs
@@ -129,7 +129,7 @@ pub trait Client : Send + Sync + 'static {
 	fn on_transaction(&self, peer_index: PeerIndex, transaction: IndexedTransaction);
 	fn on_notfound(&self, peer_index: PeerIndex, message: types::NotFound);
 	fn after_peer_nearly_blocks_verified(&self, peer_index: PeerIndex, future: EmptyBoxFuture);
-	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<(), String>;
+	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<dyn TransactionVerificationSink>) -> Result<(), String>;
 	fn install_sync_listener(&self, listener: SyncListenerRef);
 }
 
@@ -214,7 +214,7 @@ impl<T, U> Client for SynchronizationClient<T, U> where T: TaskExecutor, U: Veri
 		self.core.lock().after_peer_nearly_blocks_verified(peer_index, future);
 	}
 
-	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<(), String> {
+	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<dyn TransactionVerificationSink>) -> Result<(), String> {
 		let mut transactions_to_verify = try!(self.core.lock().accept_transaction(transaction, sink));
 
 		let next_block_height = self.shared_state.best_storage_block_height() + 1;

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -72,7 +72,7 @@ pub trait ClientCore {
 	fn on_transaction(&mut self, peer_index: PeerIndex, transaction: IndexedTransaction) -> Option<VecDeque<IndexedTransaction>>;
 	fn on_notfound(&mut self, peer_index: PeerIndex, message: types::NotFound);
 	fn after_peer_nearly_blocks_verified(&mut self, peer_index: PeerIndex, future: EmptyBoxFuture);
-	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String>;
+	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<dyn TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String>;
 	fn install_sync_listener(&mut self, listener: SyncListenerRef);
 	fn execute_synchronization_tasks(&mut self, forced_blocks_requests: Option<Vec<H256>>, final_blocks_requests: Option<Vec<H256>>);
 	fn try_switch_to_saturated_state(&mut self) -> bool;
@@ -114,7 +114,7 @@ pub struct SynchronizationClientCore<T: TaskExecutor> {
 	/// Verifying blocks futures
 	verifying_blocks_futures: HashMap<PeerIndex, (HashSet<H256>, Vec<EmptyBoxFuture>)>,
 	/// Verifying transactions futures
-	verifying_transactions_sinks: HashMap<H256, Box<TransactionVerificationSink>>,
+	verifying_transactions_sinks: HashMap<H256, Box<dyn TransactionVerificationSink>>,
 	/// Hashes of items we do not want to relay after verification is completed
 	do_not_relay: HashSet<H256>,
 	/// Block processing speed meter
@@ -538,7 +538,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		}
 	}
 
-	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String> {
+	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<dyn TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String> {
 		let hash = transaction.hash;
 		match self.try_append_transaction(transaction, true) {
 			Err(AppendTransactionError::Orphan(_)) => Err("Cannot append transaction as its inputs are unknown".to_owned()),

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -21,7 +21,7 @@ pub type RequestId = u32;
 pub type PeerIndex = usize;
 
 // No-error, no-result future
-pub type EmptyBoxFuture = Box<Future<Item=(), Error=()> + Send>;
+pub type EmptyBoxFuture = Box<dyn Future<Item=(), Error=()> + Send>;
 
 /// Reference to storage
 pub type StorageRef = storage::SharedStore;
@@ -33,7 +33,7 @@ pub type MemoryPoolRef = Arc<RwLock<MemoryPool>>;
 pub type SynchronizationStateRef = Arc<SynchronizationState>;
 
 /// Reference to peers
-pub type PeersRef = Arc<Peers>;
+pub type PeersRef = Arc<dyn Peers>;
 
 /// Reference to synchronization tasks executor
 pub type ExecutorRef<T> = Arc<T>;
@@ -51,4 +51,4 @@ pub type ServerRef<T> = Arc<T>;
 pub type LocalNodeRef = Arc<LocalNode<ServerImpl, SynchronizationClient<LocalSynchronizationTaskExecutor, AsyncVerifier>>>;
 
 /// Synchronization events listener reference
-pub type SyncListenerRef = Box<SyncListener>;
+pub type SyncListenerRef = Box<dyn SyncListener>;

--- a/sync/src/utils/message_block_headers_provider.rs
+++ b/sync/src/utils/message_block_headers_provider.rs
@@ -7,7 +7,7 @@ use primitives::hash::H256;
 /// Block headers provider from `headers` message
 pub struct MessageBlockHeadersProvider<'a> {
 	/// Synchronization chain headers provider
-	chain_provider: &'a BlockHeaderProvider,
+	chain_provider: &'a dyn BlockHeaderProvider,
 	/// headers offset
 	first_header_number: u32,
 	/// headers by hash
@@ -17,7 +17,7 @@ pub struct MessageBlockHeadersProvider<'a> {
 }
 
 impl<'a> MessageBlockHeadersProvider<'a> {
-	pub fn new(chain_provider: &'a BlockHeaderProvider, best_block_header_height: u32) -> Self {
+	pub fn new(chain_provider: &'a dyn BlockHeaderProvider, best_block_header_height: u32) -> Self {
 		MessageBlockHeadersProvider {
 			chain_provider: chain_provider,
 			first_header_number: best_block_header_height + 1,

--- a/test-data/src/block.rs
+++ b/test-data/src/block.rs
@@ -308,11 +308,11 @@ impl<F> TransactionBuilder<F> where F: Invoke<chain::Transaction> {
 		let raw_input_size = 40;
 		let script_len_size = match size {
 			//0...(0xfc + 1) => 1,
-			0...0xfd => 1,
+			0..=0xfd => 1,
 			//0xfd...(0xffff + 3) => 3,
-			0xfd...0x10002 => 3,
+			0xfd..=0x10002 => 3,
 			//0x10000...(0xffff_ffff + 5) => 5,
-			0x10000...0x1_0000_0004 => 5,
+			0x10000..=0x1_0000_0004 => 5,
 			_ => 9,
 		};
 

--- a/verification/src/accept_block.rs
+++ b/verification/src/accept_block.rs
@@ -24,13 +24,13 @@ pub struct BlockAcceptor<'a> {
 
 impl<'a> BlockAcceptor<'a> {
 	pub fn new(
-		store: &'a TransactionOutputProvider,
+		store: &'a dyn TransactionOutputProvider,
 		consensus: &'a ConsensusParams,
 		block: CanonBlock<'a>,
 		height: u32,
 		median_time_past: u32,
 		deployments: &'a BlockDeployments<'a>,
-		headers: &'a BlockHeaderProvider,
+		headers: &'a dyn BlockHeaderProvider,
 	) -> Self {
 		BlockAcceptor {
 			finality: BlockFinality::new(block, height, deployments, headers),
@@ -59,11 +59,11 @@ pub struct BlockFinality<'a> {
 	block: CanonBlock<'a>,
 	height: u32,
 	csv_active: bool,
-	headers: &'a BlockHeaderProvider,
+	headers: &'a dyn BlockHeaderProvider,
 }
 
 impl<'a> BlockFinality<'a> {
-	fn new(block: CanonBlock<'a>, height: u32, deployments: &'a BlockDeployments<'a>, headers: &'a BlockHeaderProvider) -> Self {
+	fn new(block: CanonBlock<'a>, height: u32, deployments: &'a BlockDeployments<'a>, headers: &'a dyn BlockHeaderProvider) -> Self {
 		let csv_active = deployments.csv();
 
 		BlockFinality {
@@ -136,7 +136,7 @@ impl<'a> BlockSerializedSize<'a> {
 
 pub struct BlockSigops<'a> {
 	block: CanonBlock<'a>,
-	store: &'a TransactionOutputProvider,
+	store: &'a dyn TransactionOutputProvider,
 	consensus: &'a ConsensusParams,
 	height: u32,
 	bip16_active: bool,
@@ -146,7 +146,7 @@ pub struct BlockSigops<'a> {
 impl<'a> BlockSigops<'a> {
 	fn new(
 		block: CanonBlock<'a>,
-		store: &'a TransactionOutputProvider,
+		store: &'a dyn TransactionOutputProvider,
 		consensus: &'a ConsensusParams,
 		height: u32,
 		median_time_past: u32,
@@ -200,7 +200,7 @@ impl<'a> BlockSigops<'a> {
 
 pub struct BlockCoinbaseClaim<'a> {
 	block: CanonBlock<'a>,
-	store: &'a TransactionOutputProvider,
+	store: &'a dyn TransactionOutputProvider,
 	height: u32,
 	transaction_ordering: TransactionOrdering,
 }
@@ -209,7 +209,7 @@ impl<'a> BlockCoinbaseClaim<'a> {
 	fn new(
 		block: CanonBlock<'a>,
 		consensus_params: &ConsensusParams,
-		store: &'a TransactionOutputProvider,
+		store: &'a dyn TransactionOutputProvider,
 		height: u32,
 		median_time_past: u32
 	) -> Self {

--- a/verification/src/accept_chain.rs
+++ b/verification/src/accept_chain.rs
@@ -20,9 +20,9 @@ pub struct ChainAcceptor<'a> {
 
 impl<'a> ChainAcceptor<'a> {
 	pub fn new(
-		tx_out_provider: &'a TransactionOutputProvider,
-		tx_meta_provider: &'a TransactionMetaProvider,
-		header_provider: &'a BlockHeaderProvider,
+		tx_out_provider: &'a dyn TransactionOutputProvider,
+		tx_meta_provider: &'a dyn TransactionMetaProvider,
+		header_provider: &'a dyn BlockHeaderProvider,
 		consensus: &'a ConsensusParams,
 		verification_level: VerificationLevel,
 		block: CanonBlock<'a>,

--- a/verification/src/accept_header.rs
+++ b/verification/src/accept_header.rs
@@ -14,7 +14,7 @@ pub struct HeaderAcceptor<'a> {
 
 impl<'a> HeaderAcceptor<'a> {
 	pub fn new<D: AsRef<Deployments>>(
-		store: &'a BlockHeaderProvider,
+		store: &'a dyn BlockHeaderProvider,
 		consensus: &'a ConsensusParams,
 		header: CanonHeader<'a>,
 		height: u32,
@@ -66,13 +66,13 @@ impl<'a> HeaderVersion<'a> {
 
 pub struct HeaderWork<'a> {
 	header: CanonHeader<'a>,
-	store: &'a BlockHeaderProvider,
+	store: &'a dyn BlockHeaderProvider,
 	height: u32,
 	consensus: &'a ConsensusParams,
 }
 
 impl<'a> HeaderWork<'a> {
-	fn new(header: CanonHeader<'a>, store: &'a BlockHeaderProvider, height: u32, consensus: &'a ConsensusParams) -> Self {
+	fn new(header: CanonHeader<'a>, store: &'a dyn BlockHeaderProvider, height: u32, consensus: &'a ConsensusParams) -> Self {
 		HeaderWork {
 			header: header,
 			store: store,
@@ -95,12 +95,12 @@ impl<'a> HeaderWork<'a> {
 
 pub struct HeaderMedianTimestamp<'a> {
 	header: CanonHeader<'a>,
-	store: &'a BlockHeaderProvider,
+	store: &'a dyn BlockHeaderProvider,
 	active: bool,
 }
 
 impl<'a> HeaderMedianTimestamp<'a> {
-	fn new(header: CanonHeader<'a>, store: &'a BlockHeaderProvider, csv_active: bool) -> Self {
+	fn new(header: CanonHeader<'a>, store: &'a dyn BlockHeaderProvider, csv_active: bool) -> Self {
 		HeaderMedianTimestamp {
 			header: header,
 			store: store,

--- a/verification/src/accept_transaction.rs
+++ b/verification/src/accept_transaction.rs
@@ -28,7 +28,7 @@ pub struct TransactionAcceptor<'a> {
 impl<'a> TransactionAcceptor<'a> {
 	pub fn new(
 		// in case of block validation, it's only current block,
-		meta_store: &'a TransactionMetaProvider,
+		meta_store: &'a dyn TransactionMetaProvider,
 		// previous transaction outputs
 		// in case of block validation, that's database and currently processed block
 		output_store: DuplexTransactionOutputProvider<'a>,
@@ -86,7 +86,7 @@ pub struct MemoryPoolTransactionAcceptor<'a> {
 impl<'a> MemoryPoolTransactionAcceptor<'a> {
 	pub fn new(
 		// TODO: in case of memory pool it should be db and memory pool
-		meta_store: &'a TransactionMetaProvider,
+		meta_store: &'a dyn TransactionMetaProvider,
 		// in case of memory pool it should be db and memory pool
 		output_store: DuplexTransactionOutputProvider<'a>,
 		consensus: &'a ConsensusParams,
@@ -137,14 +137,14 @@ impl<'a> MemoryPoolTransactionAcceptor<'a> {
 /// https://github.com/libbitcoin/libbitcoin/blob/61759b2fd66041bcdbc124b2f04ed5ddc20c7312/src/chain/transaction.cpp#L780-L785
 pub struct TransactionBip30<'a> {
 	transaction: CanonTransaction<'a>,
-	store: &'a TransactionMetaProvider,
+	store: &'a dyn TransactionMetaProvider,
 	exception: bool,
 }
 
 impl<'a> TransactionBip30<'a> {
 	fn new_for_sync(
 		transaction: CanonTransaction<'a>,
-		store: &'a TransactionMetaProvider,
+		store: &'a dyn TransactionMetaProvider,
 		consensus_params: &'a ConsensusParams,
 		block_hash: &'a H256,
 		height: u32
@@ -200,12 +200,12 @@ impl<'a> TransactionMissingInputs<'a> {
 
 pub struct TransactionMaturity<'a> {
 	transaction: CanonTransaction<'a>,
-	store: &'a TransactionMetaProvider,
+	store: &'a dyn TransactionMetaProvider,
 	height: u32,
 }
 
 impl<'a> TransactionMaturity<'a> {
-	fn new(transaction: CanonTransaction<'a>, store: &'a TransactionMetaProvider, height: u32) -> Self {
+	fn new(transaction: CanonTransaction<'a>, store: &'a dyn TransactionMetaProvider, height: u32) -> Self {
 		TransactionMaturity {
 			transaction: transaction,
 			store: store,

--- a/verification/src/chain_verifier.rs
+++ b/verification/src/chain_verifier.rs
@@ -124,7 +124,7 @@ impl BackwardsCompatibleChainVerifier {
 
 	pub fn verify_block_header(
 		&self,
-		_block_header_provider: &BlockHeaderProvider,
+		_block_header_provider: &dyn BlockHeaderProvider,
 		hash: &H256,
 		header: &BlockHeader
 	) -> Result<(), Error> {
@@ -138,7 +138,7 @@ impl BackwardsCompatibleChainVerifier {
 
 	pub fn verify_mempool_transaction<T>(
 		&self,
-		block_header_provider: &BlockHeaderProvider,
+		block_header_provider: &dyn BlockHeaderProvider,
 		prevout_provider: &T,
 		height: u32,
 		time: u32,

--- a/verification/src/sigops.rs
+++ b/verification/src/sigops.rs
@@ -9,7 +9,7 @@ use script::{Script, ScriptWitness};
 /// missing, we simply ignore that fact and just carry on counting
 pub fn transaction_sigops(
 	transaction: &Transaction,
-	store: &TransactionOutputProvider,
+	store: &dyn TransactionOutputProvider,
 	bip16_active: bool,
 	checkdatasig_active: bool,
 ) -> usize {
@@ -44,7 +44,7 @@ pub fn transaction_sigops(
 
 pub fn transaction_sigops_cost(
 	transaction: &Transaction,
-	store: &TransactionOutputProvider,
+	store: &dyn TransactionOutputProvider,
 	sigops: usize,
 ) -> usize {
 	let sigops_cost = sigops * ConsensusFork::witness_scale_factor();

--- a/verification/src/timestamp.rs
+++ b/verification/src/timestamp.rs
@@ -5,14 +5,14 @@ use primitives::hash::H256;
 /// Returns median timestamp, of given header ancestors.
 /// The header should be later expected to have higher timestamp
 /// than this median timestamp
-pub fn median_timestamp(header: &BlockHeader, store: &BlockHeaderProvider) -> u32 {
+pub fn median_timestamp(header: &BlockHeader, store: &dyn BlockHeaderProvider) -> u32 {
 	median_timestamp_inclusive(header.previous_header_hash.clone(), store)
 }
 
 /// Returns median timestamp, of given header + its ancestors.
 /// The header should be later expected to have higher timestamp
 /// than this median timestamp
-pub fn median_timestamp_inclusive(previous_header_hash: H256, store: &BlockHeaderProvider) -> u32 {
+pub fn median_timestamp_inclusive(previous_header_hash: H256, store: &dyn BlockHeaderProvider) -> u32 {
 	let mut timestamps: Vec<_> = BlockAncestors::new(previous_header_hash.clone().into(), store)
 		.take(11)
 		.map(|header| header.raw.time)

--- a/verification/src/work.rs
+++ b/verification/src/work.rs
@@ -57,7 +57,7 @@ pub fn retarget_timespan(retarget_timestamp: u32, last_timestamp: u32) -> u32 {
 }
 
 /// Returns work required for given header
-pub fn work_required(parent_hash: H256, time: u32, height: u32, store: &BlockHeaderProvider, consensus: &ConsensusParams) -> Compact {
+pub fn work_required(parent_hash: H256, time: u32, height: u32, store: &dyn BlockHeaderProvider, consensus: &ConsensusParams) -> Compact {
 	let max_bits = consensus.network.max_bits().into();
 	if height == 0 {
 		return max_bits;
@@ -82,7 +82,7 @@ pub fn work_required(parent_hash: H256, time: u32, height: u32, store: &BlockHea
 	parent_header.raw.bits
 }
 
-pub fn work_required_testnet(parent_hash: H256, time: u32, height: u32, store: &BlockHeaderProvider, network: Network) -> Compact {
+pub fn work_required_testnet(parent_hash: H256, time: u32, height: u32, store: &dyn BlockHeaderProvider, network: Network) -> Compact {
 	assert!(height != 0, "cannot calculate required work for genesis block");
 
 	let mut bits = Vec::new();
@@ -115,7 +115,7 @@ pub fn work_required_testnet(parent_hash: H256, time: u32, height: u32, store: &
 }
 
 /// Algorithm used for retargeting work every 2 weeks
-pub fn work_required_retarget(parent_header: IndexedBlockHeader, height: u32, store: &BlockHeaderProvider, max_work_bits: Compact) -> Compact {
+pub fn work_required_retarget(parent_header: IndexedBlockHeader, height: u32, store: &dyn BlockHeaderProvider, max_work_bits: Compact) -> Compact {
 	let retarget_ref = (height - RETARGETING_INTERVAL).into();
 	let retarget_header = store.block_header(retarget_ref).expect("self.height != 0 && self.height % RETARGETING_INTERVAL == 0; qed");
 


### PR DESCRIPTION
Starting rust stable 1.37, many warnings are emitted for the new standard:
` trait objects without an explicit dyn are deprecated`