### PR TITLE
Fixed CLI for no-verification import

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ It is possible to import existing `bitcoind` database:
 ./target/release/pbtc import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
-By default import verifies imported the blocks. You can disable this, by adding `--verification-level==none` flag.
+By default import verifies imported the blocks. You can disable this, by adding `--verification-level=none` flag.
 
 ```
-./target/release/pbtc --btc --verification-level==none import "$BITCOIND_DB/Bitcoin/blocks"
+./target/release/pbtc --btc --verification-level=none import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
 ## Command line interface

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ It is possible to import existing `bitcoind` database:
 By default import verifies imported the blocks. You can disable this, by adding `--verification-level==none` flag.
 
 ```
-./target/release/pbtc import "#BITCOIND_DB/Bitcoin/blocks" --btc --skip-verification
+./target/release/pbtc --btc --verification-level==none import "$BITCOIND_DB/Bitcoin/blocks"
 ```
 
 ## Command line interface


### PR DESCRIPTION
`--skip-verification` flag seems to be quiet outdated