### PR TITLE
[Cargo.toml,*.rs] Added support for nightly Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,306 +4,358 @@
 name = "abstract-ns"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f451afbdf8ed8c8f8a98433055bb9a6b7a72aef4baff16227d2a43dd547f43b"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "quick-error",
+ "rand 0.3.22",
 ]
 
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2",
 ]
 
 [[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 
 [[package]]
 name = "app_dirs"
 version = "1.2.1"
 source = "git+https://github.com/paritytech/app-dirs-rs#0b37f9481ce29e9d5174ad185bca695b206368eb"
 dependencies = [
- "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ole32-sys",
+ "shell32-sys",
+ "winapi 0.2.8",
+ "xdg",
 ]
 
 [[package]]
 name = "arrayvec"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0ef4a9820019a0c91d918918c93dc71d469f581a49b47ddc1d285d4270bbe2"
 dependencies = [
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "assert_matches"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
 name = "atty"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "libc",
+ "termion",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "base58"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "safemem",
 ]
 
 [[package]]
 name = "bencher"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "db 0.1.0",
- "network 0.1.0",
- "primitives 0.1.0",
- "storage 0.1.0",
- "test-data 0.1.0",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "verification 0.1.0",
-]
-
-[[package]]
-name = "bigint"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "chain",
+ "db",
+ "network",
+ "primitives",
+ "storage",
+ "test-data",
+ "time",
+ "verification",
 ]
 
 [[package]]
 name = "bit-vec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 
 [[package]]
 name = "bitcrypto"
 version = "0.1.0"
 dependencies = [
- "primitives 0.1.0",
- "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitives",
+ "rust-crypto",
+ "siphasher",
 ]
 
 [[package]]
 name = "bitflags"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 
 [[package]]
 name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+
+[[package]]
+name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium",
+]
+
+[[package]]
+name = "byte-slice-cast"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
 name = "byteorder"
-version = "1.1.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "iovec",
 ]
 
 [[package]]
 name = "cc"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 
 [[package]]
 name = "chain"
 version = "0.1.0"
 dependencies = [
- "bitcrypto 0.1.0",
- "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serialization 0.1.0",
- "serialization_derive 0.1.0",
+ "bitcrypto",
+ "ethereum-types 0.9.2",
+ "heapsize 0.4.1",
+ "primitives",
+ "rayon 1.0.1",
+ "rustc-hex 2.1.0",
+ "serialization",
+ "serialization_derive",
 ]
 
 [[package]]
 name = "chrono"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 dependencies = [
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num",
+ "time",
 ]
 
 [[package]]
 name = "clap"
 version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "atty",
+ "bitflags 0.9.1",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+ "yaml-rust",
 ]
 
 [[package]]
 name = "crossbeam-deque"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 dependencies = [
- "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 dependencies = [
- "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.6",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "nodrop",
+ "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "csv"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
 dependencies = [
- "csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv-core",
+ "serde",
 ]
 
 [[package]]
 name = "csv-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
 dependencies = [
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1",
 ]
 
 [[package]]
 name = "db"
 version = "0.1.0"
 dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "elastic-array 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rocksdb 0.4.5 (git+https://github.com/ethcore/rust-rocksdb)",
- "serialization 0.1.0",
- "storage 0.1.0",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "test-data 0.1.0",
+ "bit-vec",
+ "chain",
+ "elastic-array",
+ "log 0.4.1",
+ "lru-cache",
+ "parking_lot",
+ "primitives",
+ "rocksdb",
+ "serialization",
+ "storage",
+ "tempdir",
+ "test-data",
 ]
 
 [[package]]
 name = "display_derive"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bba5dcd6d2855639fcf65a9af7bbad0bfb6dbf6fe68fba70bab39a6eb973ef4"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
 name = "domain"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1850bf2c3c3349e1dba2aa214d86cf9edaa057a09ce46b1a02d5c07d5da5e65"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "futures",
+ "rand 0.3.22",
+ "tokio-core",
 ]
 
 [[package]]
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 
 [[package]]
 name = "either"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56b59865bce947ac5958779cfa508f6c3b9497cc762b7e24a12d11ccde2c4f"
 
 [[package]]
 name = "elastic-array"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058dc1040bbf28853bc48ec5f59190bac41b246c43c30064f0d318e6d1362fd6"
 dependencies = [
- "heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.3.9",
 ]
 
 [[package]]
 name = "env_logger"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
 dependencies = [
- "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty",
+ "chrono",
+ "log 0.4.1",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -311,165 +363,307 @@ name = "eth-secp256k1"
 version = "0.5.7"
 source = "git+https://github.com/ethcore/rust-secp256k1#6370d63adf4e8c91e2eae9225eef4b4e0294c5d0"
 dependencies = [
- "arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.6",
+ "cc",
+ "libc",
+ "rand 0.3.22",
+ "rustc-serialize",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f240172b976e2421fa5485e45cd45287bbdb56d742aa3a1d77005c49071a8518"
+dependencies = [
+ "crunchy 0.1.6",
+ "ethereum-types-serialize",
+ "fixed-hash 0.1.3",
+ "serde",
+ "tiny-keccak 1.5.0",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
+dependencies = [
+ "crunchy 0.2.2",
+ "fixed-hash 0.6.1",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad6fb0e4ab648f4d8d8314c340c47f9e805b085b78be1b8da4676534cb419df"
+dependencies = [
+ "crunchy 0.1.6",
+ "ethbloom 0.4.2",
+ "ethereum-types-serialize",
+ "fixed-hash 0.1.3",
+ "rustc_version",
+ "serde",
+ "uint 0.1.0",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
+dependencies = [
+ "ethbloom 0.9.2",
+ "fixed-hash 0.6.1",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint 0.8.5",
+]
+
+[[package]]
+name = "ethereum-types-serialize"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21c520ebc46522d519aec9cba2b7115d49cea707d771b772c46bec61aa0daeb8"
+dependencies = [
+ "heapsize 0.4.1",
+ "libc",
+ "rand 0.4.2",
+ "rustc-hex 1.0.0",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
+dependencies = [
+ "byteorder",
+ "rand 0.7.3",
+ "rustc-hex 2.1.0",
+ "static_assertions",
 ]
 
 [[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
 name = "fuchsia-zircon"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
 dependencies = [
- "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon-sys 0.2.0",
 ]
 
 [[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1",
+ "fuchsia-zircon-sys 0.3.3",
 ]
 
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0",
 ]
 
 [[package]]
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
 
 [[package]]
 name = "futures-cpupool"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "num_cpus",
 ]
 
 [[package]]
 name = "gcc"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 dependencies = [
- "rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 0.8.2",
 ]
 
 [[package]]
 name = "getopts"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
+
+[[package]]
+name = "getrandom"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "globset"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
 dependencies = [
- "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "fnv",
+ "log 0.3.8",
+ "memchr 1.0.2",
+ "regex",
 ]
 
 [[package]]
 name = "heapsize"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556cd479866cf85c3f671209c85e8a6990211c916d1002c2fcb2e9b7cf60bc36"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
 ]
 
 [[package]]
 name = "heapsize"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54fab2624374e5137ae4df13bf32b0b269cb804df42d13a51221bbd431d1a237"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
 ]
 
 [[package]]
 name = "httparse"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 
 [[package]]
 name = "hyper"
 version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4959ca95f55df4265bff2ad63066147255e6fa733682cf6d1cb5eaff6e53324b"
 dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64",
+ "bytes",
+ "futures",
+ "futures-cpupool",
+ "httparse",
+ "language-tags",
+ "log 0.3.8",
+ "mime",
+ "percent-encoding",
+ "relay",
+ "time",
+ "tokio-core",
+ "tokio-io",
+ "tokio-proto",
+ "tokio-service",
+ "unicase",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "import"
 version = "0.1.0"
 dependencies = [
- "chain 0.1.0",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "serialization 0.1.0",
+ "chain",
+ "log 0.4.1",
+ "primitives",
+ "serialization",
 ]
 
 [[package]]
 name = "iovec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 
 [[package]]
 name = "jsonrpc-core"
 version = "8.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#0eba7e745b0895b4234cd8d89b28e10e2c3c34a4"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "log 0.3.8",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -477,12 +671,12 @@ name = "jsonrpc-http-server"
 version = "8.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#0eba7e745b0895b4234cd8d89b28e10e2c3c34a4"
 dependencies = [
- "hyper 0.11.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "jsonrpc-server-utils 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper",
+ "jsonrpc-core",
+ "jsonrpc-server-utils",
+ "log 0.3.8",
+ "net2",
+ "unicase",
 ]
 
 [[package]]
@@ -490,9 +684,9 @@ name = "jsonrpc-macros"
 version = "8.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#0eba7e745b0895b4234cd8d89b28e10e2c3c34a4"
 dependencies = [
- "jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "jsonrpc-pubsub 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core",
+ "jsonrpc-pubsub",
+ "serde",
 ]
 
 [[package]]
@@ -500,9 +694,9 @@ name = "jsonrpc-pubsub"
 version = "8.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#0eba7e745b0895b4234cd8d89b28e10e2c3c34a4"
 dependencies = [
- "jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core",
+ "log 0.3.8",
+ "parking_lot",
 ]
 
 [[package]]
@@ -510,491 +704,625 @@ name = "jsonrpc-server-utils"
 version = "8.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#0eba7e745b0895b4234cd8d89b28e10e2c3c34a4"
 dependencies = [
- "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "globset",
+ "jsonrpc-core",
+ "log 0.3.8",
+ "tokio-core",
+ "tokio-io",
 ]
 
 [[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "keys"
 version = "0.1.0"
 dependencies = [
- "base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcrypto 0.1.0",
- "eth-secp256k1 0.5.7 (git+https://github.com/ethcore/rust-secp256k1)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base58",
+ "bitcrypto",
+ "eth-secp256k1",
+ "lazy_static",
+ "primitives",
+ "rand 0.4.2",
+ "rustc-hex 2.1.0",
 ]
 
 [[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
 
 [[package]]
 name = "libc"
-version = "0.2.33"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 
 [[package]]
 name = "linked-hash-map"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 
 [[package]]
 name = "local-encoding"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "skeptic 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "skeptic",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "log"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 
 [[package]]
 name = "log"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "logs"
 version = "0.1.0"
 dependencies = [
- "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term",
+ "env_logger",
+ "log 0.4.1",
+ "time",
 ]
 
 [[package]]
 name = "lru-cache"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 dependencies = [
- "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.4.2",
 ]
 
 [[package]]
 name = "memchr"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "memoffset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 
 [[package]]
 name = "message"
 version = "0.1.0"
 dependencies = [
- "bitcrypto 0.1.0",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "network 0.1.0",
- "primitives 0.1.0",
- "serialization 0.1.0",
- "serialization_derive 0.1.0",
+ "bitcrypto",
+ "byteorder",
+ "chain",
+ "network",
+ "primitives",
+ "serialization",
+ "serialization_derive",
 ]
 
 [[package]]
 name = "mime"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 dependencies = [
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase",
 ]
 
 [[package]]
 name = "miner"
 version = "0.1.0"
 dependencies = [
- "bitcrypto 0.1.0",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "db 0.1.0",
- "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "keys 0.1.0",
- "network 0.1.0",
- "primitives 0.1.0",
- "script 0.1.0",
- "serialization 0.1.0",
- "storage 0.1.0",
- "test-data 0.1.0",
- "verification 0.1.0",
+ "bitcrypto",
+ "byteorder",
+ "chain",
+ "db",
+ "heapsize 0.4.1",
+ "keys",
+ "network",
+ "primitives",
+ "script",
+ "serialization",
+ "storage",
+ "test-data",
+ "verification",
 ]
 
 [[package]]
 name = "mio"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8411968194c7b139e9105bc4ae7db0bae232af087147e72f0616ebf5fdb9cb"
 dependencies = [
- "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.2.1",
+ "fuchsia-zircon-sys 0.2.0",
+ "iovec",
+ "kernel32-sys",
+ "lazycell",
+ "libc",
+ "log 0.3.8",
+ "miow",
+ "net2",
+ "slab 0.3.0",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "miow"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
 name = "murmur3"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fbfc749b3a5d9c313c5e0cd61788f1f219ebd2f22de25996df0481c08949e4"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
 ]
 
 [[package]]
 name = "net2"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
 name = "network"
 version = "0.1.0"
 dependencies = [
- "chain 0.1.0",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
+ "chain",
+ "ethereum-types 0.9.2",
+ "lazy_static",
+ "primitives",
 ]
 
 [[package]]
 name = "nodrop"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 
 [[package]]
 name = "ns-dns-tokio"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d13b872a5a65428c1d4628fa04391f5c05ba8a23d5ee3094e22284fdddebed86"
 dependencies = [
- "abstract-ns 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "domain 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abstract-ns",
+ "domain",
+ "futures",
+ "tokio-core",
 ]
 
 [[package]]
 name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-iter",
+ "num-traits 0.2.0",
 ]
 
 [[package]]
 name = "num-integer"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
 dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.0",
 ]
 
 [[package]]
 name = "num-iter"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
 dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer",
+ "num-traits 0.2.0",
 ]
 
 [[package]]
 name = "num-traits"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 
 [[package]]
 name = "num-traits"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 
 [[package]]
 name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
 ]
 
 [[package]]
 name = "ole32-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "owning_ref"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
 dependencies = [
- "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait",
 ]
 
 [[package]]
 name = "p2p"
 version = "0.1.0"
 dependencies = [
- "abstract-ns 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcrypto 0.1.0",
- "csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "message 0.1.0",
- "network 0.1.0",
- "ns-dns-tokio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serialization 0.1.0",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abstract-ns",
+ "bitcrypto",
+ "csv",
+ "futures",
+ "futures-cpupool",
+ "log 0.4.1",
+ "message",
+ "network",
+ "ns-dns-tokio",
+ "parking_lot",
+ "primitives",
+ "rand 0.4.2",
+ "serialization",
+ "time",
+ "tokio-core",
+ "tokio-io",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d38aeaffc032ec69faa476b3caaca8d4dd7f3f798137ff30359e5c7869ceb6"
+dependencies = [
+ "arrayvec 0.5.1",
+ "bitvec",
+ "byte-slice-cast",
+ "serde",
 ]
 
 [[package]]
 name = "parking_lot"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
 dependencies = [
- "owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "libc",
+ "rand 0.3.22",
+ "smallvec 0.4.5",
+ "winapi 0.2.8",
 ]
 
 [[package]]
 name = "pbtc"
 version = "0.1.0"
 dependencies = [
- "app_dirs 1.2.1 (git+https://github.com/paritytech/app-dirs-rs)",
- "chain 0.1.0",
- "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "db 0.1.0",
- "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "import 0.1.0",
- "keys 0.1.0",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "logs 0.1.0",
- "message 0.1.0",
- "miner 0.1.0",
- "network 0.1.0",
- "p2p 0.1.0",
- "primitives 0.1.0",
- "rpc 0.1.0",
- "script 0.1.0",
- "storage 0.1.0",
- "sync 0.1.0",
- "verification 0.1.0",
+ "app_dirs",
+ "chain",
+ "clap",
+ "db",
+ "env_logger",
+ "ethereum-types 0.2.2",
+ "import",
+ "keys",
+ "libc",
+ "log 0.4.1",
+ "logs",
+ "message",
+ "miner",
+ "network",
+ "p2p",
+ "primitives",
+ "rpc",
+ "script",
+ "storage",
+ "sync",
+ "verification",
 ]
 
 [[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "primitive-types"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
+dependencies = [
+ "fixed-hash 0.6.1",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint 0.8.5",
+]
 
 [[package]]
 name = "primitives"
 version = "0.1.0"
 dependencies = [
- "bigint 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder",
+ "ethereum-types 0.9.2",
+ "heapsize 0.4.1",
+ "rustc-hex 2.1.0",
 ]
 
 [[package]]
 name = "pulldown-cmark"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 dependencies = [
- "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts",
 ]
 
 [[package]]
 name = "quick-error"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 
 [[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3",
+ "libc",
+ "rand 0.4.2",
 ]
 
 [[package]]
 name = "rand"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3",
+ "libc",
+ "winapi 0.3.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
 name = "rayon"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 dependencies = [
- "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core",
 ]
 
 [[package]]
 name = "rayon"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
 dependencies = [
- "either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either",
+ "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque",
+ "lazy_static",
+ "libc",
+ "num_cpus",
+ "rand 0.4.2",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 
 [[package]]
 name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 dependencies = [
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 dependencies = [
- "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr 1.0.2",
+ "regex-syntax",
+ "thread_local",
+ "utf8-ranges",
 ]
 
 [[package]]
 name = "regex-syntax"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 
 [[package]]
 name = "relay"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+]
+
+[[package]]
+name = "rlp"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
+dependencies = [
+ "rustc-hex 2.1.0",
 ]
 
 [[package]]
@@ -1002,9 +1330,9 @@ name = "rocksdb"
 version = "0.4.5"
 source = "git+https://github.com/ethcore/rust-rocksdb#4364caec4dd5da1a1d78c39276774ee65bf55c7d"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb-sys 0.3.0 (git+https://github.com/ethcore/rust-rocksdb)",
+ "libc",
+ "local-encoding",
+ "rocksdb-sys",
 ]
 
 [[package]]
@@ -1012,677 +1340,636 @@ name = "rocksdb-sys"
 version = "0.3.0"
 source = "git+https://github.com/ethcore/rust-rocksdb#4364caec4dd5da1a1d78c39276774ee65bf55c7d"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
 ]
 
 [[package]]
 name = "rpc"
 version = "0.1.0"
 dependencies = [
- "chain 0.1.0",
- "db 0.1.0",
- "jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "jsonrpc-http-server 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "jsonrpc-macros 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
- "keys 0.1.0",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "miner 0.1.0",
- "network 0.1.0",
- "p2p 0.1.0",
- "primitives 0.1.0",
- "rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "script 0.1.0",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serialization 0.1.0",
- "storage 0.1.0",
- "sync 0.1.0",
- "test-data 0.1.0",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "verification 0.1.0",
+ "chain",
+ "db",
+ "jsonrpc-core",
+ "jsonrpc-http-server",
+ "jsonrpc-macros",
+ "keys",
+ "log 0.4.1",
+ "miner",
+ "network",
+ "p2p",
+ "primitives",
+ "rustc-hex 2.1.0",
+ "script",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serialization",
+ "storage",
+ "sync",
+ "test-data",
+ "tokio-core",
+ "verification",
 ]
 
 [[package]]
 name = "rust-crypto"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc",
+ "libc",
+ "rand 0.3.22",
+ "rustc-serialize",
+ "time",
 ]
 
 [[package]]
 name = "rustc-hex"
-version = "2.0.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
 dependencies = [
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver",
 ]
 
 [[package]]
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 
 [[package]]
 name = "scoped-tls"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "script"
 version = "0.1.0"
 dependencies = [
- "bitcrypto 0.1.0",
- "chain 0.1.0",
- "keys 0.1.0",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "serialization 0.1.0",
+ "bitcrypto",
+ "chain",
+ "keys",
+ "log 0.4.1",
+ "primitives",
+ "serialization",
 ]
 
 [[package]]
 name = "semver"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.21"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54c9a88f2da7238af84b5101443f0c0d0a3bbdc455e34a5c9497b1903ed55d5"
 
 [[package]]
 name = "serde_derive"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652bc323d694dc925829725ec6c890156d8e70ae5202919869cb00fe2eff3788"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
 name = "serde_derive_internals"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
 dependencies = [
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn",
+ "synom",
 ]
 
 [[package]]
 name = "serde_json"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4586746d1974a030c48919731ecffd0ed28d0c40749d0d18d43b3a7d6c9b20e"
 dependencies = [
- "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dtoa",
+ "itoa",
+ "num-traits 0.1.40",
+ "serde",
 ]
 
 [[package]]
 name = "serialization"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
+ "byteorder",
+ "primitives",
 ]
 
 [[package]]
 name = "serialization_derive"
 version = "0.1.0"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serialization 0.1.0",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "serialization",
+ "syn",
 ]
 
 [[package]]
 name = "shell32-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4",
+ "winapi-build",
 ]
 
 [[package]]
 name = "siphasher"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833011ca526bd88f16778d32c699d325a9ad302fa06381cd66f7be63351d3f6d"
 
 [[package]]
 name = "skeptic"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ebf8a06f5f8bae61ae5bbc7af7aac4ef6907ae975130faba1199e5fe82256a"
 dependencies = [
- "pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark",
+ "tempdir",
 ]
 
 [[package]]
 name = "slab"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 
 [[package]]
 name = "slab"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 
 [[package]]
 name = "smallvec"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 
 [[package]]
 name = "smallvec"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90c5e5fe535e48807ab94fc611d323935f39d4660c52b26b96446a7b33aef10"
 
 [[package]]
 name = "stable_deref_trait"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage"
 version = "0.1.0"
 dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "display_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "elastic-array 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "network 0.1.0",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "serialization 0.1.0",
+ "bit-vec",
+ "chain",
+ "display_derive",
+ "elastic-array",
+ "lru-cache",
+ "network",
+ "parking_lot",
+ "primitives",
+ "serialization",
 ]
 
 [[package]]
 name = "strsim"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 
 [[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "synom",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "sync"
 version = "0.1.0"
 dependencies = [
- "bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcrypto 0.1.0",
- "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chain 0.1.0",
- "db 0.1.0",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "message 0.1.0",
- "miner 0.1.0",
- "murmur3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "network 0.1.0",
- "p2p 0.1.0",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "script 0.1.0",
- "serialization 0.1.0",
- "storage 0.1.0",
- "test-data 0.1.0",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "verification 0.1.0",
+ "bit-vec",
+ "bitcrypto",
+ "byteorder",
+ "chain",
+ "db",
+ "futures",
+ "linked-hash-map 0.3.0",
+ "log 0.4.1",
+ "message",
+ "miner",
+ "murmur3",
+ "network",
+ "p2p",
+ "parking_lot",
+ "primitives",
+ "rand 0.4.2",
+ "script",
+ "serialization",
+ "storage",
+ "test-data",
+ "time",
+ "verification",
 ]
 
 [[package]]
 name = "synom"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "synstructure"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "take"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 
 [[package]]
 name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 dependencies = [
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.22",
 ]
 
 [[package]]
 name = "termcolor"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9065bced9c3e43453aa3d56f1e98590b8455b341d2fa191a1090c0dd0b242c75"
 dependencies = [
- "wincolor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wincolor",
 ]
 
 [[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 dependencies = [
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc",
+ "redox_syscall",
+ "redox_termios",
 ]
 
 [[package]]
 name = "test-data"
 version = "0.1.0"
 dependencies = [
- "chain 0.1.0",
- "primitives 0.1.0",
- "script 0.1.0",
- "serialization 0.1.0",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chain",
+ "primitives",
+ "script",
+ "serialization",
+ "time",
 ]
 
 [[package]]
 name = "textwrap"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 dependencies = [
- "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
+ "unreachable",
 ]
 
 [[package]]
 name = "time"
 version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys",
+ "libc",
+ "redox_syscall",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+dependencies = [
+ "crunchy 0.2.2",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy 0.2.2",
 ]
 
 [[package]]
 name = "tokio-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c843a027f7c1df5f81e7734a0df3f67bf329411781ebf36393ce67beef6071e3"
 dependencies = [
- "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures",
+ "iovec",
+ "log 0.3.8",
+ "mio",
+ "scoped-tls",
+ "slab 0.4.0",
+ "tokio-io",
 ]
 
 [[package]]
 name = "tokio-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
 dependencies = [
- "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes",
+ "futures",
+ "log 0.3.8",
 ]
 
 [[package]]
 name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "log 0.3.8",
+ "net2",
+ "rand 0.3.22",
+ "slab 0.3.0",
+ "smallvec 0.2.1",
+ "take",
+ "tokio-core",
+ "tokio-io",
+ "tokio-service",
 ]
 
 [[package]]
 name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 dependencies = [
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+]
+
+[[package]]
+name = "uint"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ed1e25ded4e37e0967b1f12d5f910b32f979768d4f48e2f6ca7b6e7130b44e"
+dependencies = [
+ "byteorder",
+ "heapsize 0.4.1",
+ "rustc-hex 1.0.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "uint"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+dependencies = [
+ "byteorder",
+ "crunchy 0.2.2",
+ "rustc-hex 2.1.0",
+ "static_assertions",
 ]
 
 [[package]]
 name = "unicase"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 dependencies = [
- "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check",
 ]
 
 [[package]]
 name = "unicode-width"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unreachable"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void",
 ]
 
 [[package]]
 name = "utf8-ranges"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 
 [[package]]
 name = "vec_map"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 
 [[package]]
 name = "verification"
 version = "0.1.0"
 dependencies = [
- "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitcrypto 0.1.0",
- "chain 0.1.0",
- "db 0.1.0",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "network 0.1.0",
- "parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "primitives 0.1.0",
- "rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "script 0.1.0",
- "serialization 0.1.0",
- "storage 0.1.0",
- "test-data 0.1.0",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches",
+ "bitcrypto",
+ "chain",
+ "db",
+ "ethereum-types 0.9.2",
+ "lazy_static",
+ "log 0.4.1",
+ "network",
+ "parking_lot",
+ "primitives",
+ "rayon 1.0.1",
+ "script",
+ "serialization",
+ "storage",
+ "test-data",
+ "time",
 ]
 
 [[package]]
 name = "version_check"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
 
 [[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
 name = "winapi-build"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wincolor"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0878187fa88838d2006c0a76f30d64797098426245b375383f60acb6aed8a203"
 dependencies = [
- "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4",
 ]
 
 [[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
 name = "xdg"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
 
 [[package]]
 name = "yaml-rust"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum abstract-ns 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2f451afbdf8ed8c8f8a98433055bb9a6b7a72aef4baff16227d2a43dd547f43b"
-"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum app_dirs 1.2.1 (git+https://github.com/paritytech/app-dirs-rs)" = "<none>"
-"checksum arrayvec 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0ef4a9820019a0c91d918918c93dc71d469f581a49b47ddc1d285d4270bbe2"
-"checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
-"checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
-"checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
-"checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-"checksum bigint 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5d1b3ef6756498df0e2c6bb67c065f4154d0ecd721eb5b3c3f865c8012b9fd74"
-"checksum bit-vec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
-"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
-"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
-"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
-"checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
-"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
-"checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
-"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
-"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
-"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum csv 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71903184af9960c555e7f3b32ff17390d20ecaaf17d4f18c4a0993f2df8a49e3"
-"checksum csv-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dd8e6d86f7ba48b4276ef1317edc8cc36167546d8972feb4a2b5fec0b374105"
-"checksum display_derive 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bba5dcd6d2855639fcf65a9af7bbad0bfb6dbf6fe68fba70bab39a6eb973ef4"
-"checksum domain 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1850bf2c3c3349e1dba2aa214d86cf9edaa057a09ce46b1a02d5c07d5da5e65"
-"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "740178ddf48b1a9e878e6d6509a1442a2d42fd2928aae8e7a6f8a36fb01981b3"
-"checksum elastic-array 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "058dc1040bbf28853bc48ec5f59190bac41b246c43c30064f0d318e6d1362fd6"
-"checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
-"checksum eth-secp256k1 0.5.7 (git+https://github.com/ethcore/rust-secp256k1)" = "<none>"
-"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
-"checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
-"checksum getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "b900c08c1939860ce8b54dc6a89e26e00c04c380fd0e09796799bd7f12861e05"
-"checksum globset 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d069fe6beb9be359ef505650b3f73228c5591a3c4b1f32be2f4f44459ffa3a"
-"checksum heapsize 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "556cd479866cf85c3f671209c85e8a6990211c916d1002c2fcb2e9b7cf60bc36"
-"checksum heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "54fab2624374e5137ae4df13bf32b0b269cb804df42d13a51221bbd431d1a237"
-"checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
-"checksum hyper 0.11.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4959ca95f55df4265bff2ad63066147255e6fa733682cf6d1cb5eaff6e53324b"
-"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
-"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
-"checksum jsonrpc-core 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)" = "<none>"
-"checksum jsonrpc-http-server 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)" = "<none>"
-"checksum jsonrpc-macros 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)" = "<none>"
-"checksum jsonrpc-pubsub 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)" = "<none>"
-"checksum jsonrpc-server-utils 8.0.0 (git+https://github.com/ethcore/jsonrpc.git)" = "<none>"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
-"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
-"checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
-"checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum local-encoding 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1ceb20f39ff7ae42f3ff9795f3986b1daad821caaa1e1732a0944103a5a1a66"
-"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
-"checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
-"checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
-"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
-"checksum mio 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0e8411968194c7b139e9105bc4ae7db0bae232af087147e72f0616ebf5fdb9cb"
-"checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum murmur3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fbfc749b3a5d9c313c5e0cd61788f1f219ebd2f22de25996df0481c08949e4"
-"checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
-"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
-"checksum ns-dns-tokio 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d13b872a5a65428c1d4628fa04391f5c05ba8a23d5ee3094e22284fdddebed86"
-"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
-"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
-"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
-"checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
-"checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
-"checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parking_lot 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "149d8f5b97f3c1133e3cfcd8886449959e856b557ff281e292b733d7c69e005e"
-"checksum parking_lot_core 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f610cb9664da38e417ea3225f23051f589851999535290e077939838ab7a595"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
-"checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
-"checksum rayon 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80e811e76f1dbf68abf87a759083d34600017fc4e10b6bd5ad84a700f9dba4b1"
-"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
-"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
-"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
-"checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
-"checksum rocksdb 0.4.5 (git+https://github.com/ethcore/rust-rocksdb)" = "<none>"
-"checksum rocksdb-sys 0.3.0 (git+https://github.com/ethcore/rust-rocksdb)" = "<none>"
-"checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
-"checksum rustc-hex 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b03280c2813907a030785570c577fb27d3deec8da4c18566751ade94de0ace"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-"checksum rustc_version 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9743a7670d88d5d52950408ecdb7c71d8986251ab604d4689dd2ca25c9bca69"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
-"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "6eda663e865517ee783b0891a3f6eb3a253e0b0dabb46418969ee9635beadd9e"
-"checksum serde_derive 1.0.21 (registry+https://github.com/rust-lang/crates.io-index)" = "652bc323d694dc925829725ec6c890156d8e70ae5202919869cb00fe2eff3788"
-"checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"
-"checksum serde_json 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e4586746d1974a030c48919731ecffd0ed28d0c40749d0d18d43b3a7d6c9b20e"
-"checksum shell32-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72f20b8f3c060374edb8046591ba28f62448c369ccbdc7b02075103fb3a9e38d"
-"checksum siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "833011ca526bd88f16778d32c699d325a9ad302fa06381cd66f7be63351d3f6d"
-"checksum skeptic 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24ebf8a06f5f8bae61ae5bbc7af7aac4ef6907ae975130faba1199e5fe82256a"
-"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
-"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
-"checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
-"checksum smallvec 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f90c5e5fe535e48807ab94fc611d323935f39d4660c52b26b96446a7b33aef10"
-"checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
-"checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
-"checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum termcolor 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9065bced9c3e43453aa3d56f1e98590b8455b341d2fa191a1090c0dd0b242c75"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
-"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
-"checksum tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c843a027f7c1df5f81e7734a0df3f67bf329411781ebf36393ce67beef6071e3"
-"checksum tokio-io 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "514aae203178929dbf03318ad7c683126672d4d96eccb77b29603d33c9e25743"
-"checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
-"checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
-"checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
-"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
-"checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum wincolor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0878187fa88838d2006c0a76f30d64797098426245b375383f60acb6aed8a203"
-"checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-"checksum xdg 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a66b7c2281ebde13cf4391d70d4c7e5946c3c25e72a7b859ca8f677dcd0b0c61"
-"checksum yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,46 +1,82 @@
 [package]
-name = "pbtc"
-version = "0.1.0"
-license = "GPL-3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Parity bitcoin client."
+license = "GPL-3.0"
+name = "pbtc"
+version = "0.1.0"
+[[bin]]
+name = "pbtc"
+path = "pbtc/main.rs"
 
 [dependencies]
-log = "0.4"
 env_logger = "0.5"
-app_dirs = { git = "https://github.com/paritytech/app-dirs-rs" }
+ethereum-types = "*"
 libc = "0.2"
-clap = { version = "2", features = ["yaml"] }
-chain = { path = "chain" }
-keys = { path = "keys" }
-message = { path = "message" }
-network = { path = "network" }
-miner = { path = "miner" }
-p2p = { path = "p2p" }
-script = { path = "script" }
-storage = { path = "storage" }
-db = { path = "db" }
-verification = { path = "verification" }
-sync = { path = "sync" }
-import = { path = "import" }
-logs = { path = "logs" }
-rpc = { path = "rpc" }
-primitives = { path = "primitives" }
+log = "0.4"
 
+[dependencies.app_dirs]
+git = "https://github.com/paritytech/app-dirs-rs"
+
+[dependencies.chain]
+path = "chain"
+
+[dependencies.clap]
+features = ["yaml"]
+version = "2"
+
+[dependencies.db]
+path = "db"
+
+[dependencies.import]
+path = "import"
+
+[dependencies.keys]
+path = "keys"
+
+[dependencies.logs]
+path = "logs"
+
+[dependencies.message]
+path = "message"
+
+[dependencies.miner]
+path = "miner"
+
+[dependencies.network]
+path = "network"
+
+[dependencies.p2p]
+path = "p2p"
+
+[dependencies.primitives]
+path = "primitives"
+
+[dependencies.rpc]
+path = "rpc"
+
+[dependencies.script]
+path = "script"
+
+[dependencies.storage]
+path = "storage"
+
+[dependencies.sync]
+path = "sync"
+
+[dependencies.verification]
+path = "verification"
+
+[profile]
 [profile.dev]
 debug = true
-panic = 'abort'
+panic = "abort"
 
 [profile.release]
 debug = true
-panic = 'abort'
+panic = "abort"
 
 [profile.test]
 debug = true
-
-[[bin]]
-path = "pbtc/main.rs"
-name = "pbtc"
 
 [workspace]
 members = ["bencher"]

--- a/bencher/src/database.rs
+++ b/bencher/src/database.rs
@@ -1,252 +1,295 @@
 use chain::IndexedBlock;
-use storage::{BlockProvider, BlockRef, BlockOrigin, ForkChain};
 use db::BlockChainDatabase;
+use storage::{BlockOrigin, BlockProvider, BlockRef, ForkChain};
 use test_data;
 
 use super::Benchmark;
 
 pub fn fetch(benchmark: &mut Benchmark) {
-	// params
-	const BLOCKS: usize = 1000;
+    // params
+    const BLOCKS: usize = 1000;
 
-	benchmark.samples(BLOCKS);
+    benchmark.samples(BLOCKS);
 
-	// test setup
-	let genesis: IndexedBlock = test_data::genesis().into();
-	let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
+    // test setup
+    let genesis: IndexedBlock = test_data::genesis().into();
+    let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
 
-	let mut rolling_hash = genesis.hash().clone();
-	let mut blocks = Vec::new();
-	let mut hashes = Vec::new();
+    let mut rolling_hash = genesis.hash().clone();
+    let mut blocks = Vec::new();
+    let mut hashes = Vec::new();
 
-	for x in 0..BLOCKS {
-		let next_block = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(rolling_hash.clone()).nonce(x as u32).build()
-			.build();
-		rolling_hash = next_block.hash();
-		blocks.push(next_block);
-		hashes.push(rolling_hash.clone());
-	}
+    for x in 0..BLOCKS {
+        let next_block = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32)
+            .build()
+            .build();
+        rolling_hash = next_block.hash();
+        blocks.push(next_block);
+        hashes.push(rolling_hash.clone());
+    }
 
-	for block in blocks.into_iter() {
-		let block: IndexedBlock = block.into();
-		let hash = block.hash().clone();
-		store.insert(block).unwrap();
-		store.canonize(&hash).unwrap();
-	}
+    for block in blocks.into_iter() {
+        let block: IndexedBlock = block.into();
+        let hash = block.hash().clone();
+        store.insert(block).unwrap();
+        store.canonize(&hash).unwrap();
+    }
 
-	// bench
-	benchmark.start();
-	for _ in 0..BLOCKS {
-		let block = store.block(BlockRef::Hash(hashes[0].clone())).unwrap();
-		assert_eq!(block.hash(), &hashes[0]);
-	}
-	benchmark.stop();
+    // bench
+    benchmark.start();
+    for _ in 0..BLOCKS {
+        let block = store.block(BlockRef::Hash(hashes[0].clone())).unwrap();
+        assert_eq!(block.hash(), &hashes[0]);
+    }
+    benchmark.stop();
 }
 
 pub fn write(benchmark: &mut Benchmark) {
-	// params
-	const BLOCKS: usize = 1000;
-	benchmark.samples(BLOCKS);
+    // params
+    const BLOCKS: usize = 1000;
+    benchmark.samples(BLOCKS);
 
-	// setup
-	let genesis: IndexedBlock = test_data::genesis().into();
-	let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
+    // setup
+    let genesis: IndexedBlock = test_data::genesis().into();
+    let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
 
-	let mut rolling_hash = genesis.hash().clone();
+    let mut rolling_hash = genesis.hash().clone();
 
-	let mut blocks: Vec<IndexedBlock> = Vec::new();
+    let mut blocks: Vec<IndexedBlock> = Vec::new();
 
-	for x in 0..BLOCKS {
-		let next_block = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(rolling_hash.clone()).nonce(x as u32).build()
-			.build();
-		rolling_hash = next_block.hash();
-		blocks.push(next_block.into());
-	}
+    for x in 0..BLOCKS {
+        let next_block = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32)
+            .build()
+            .build();
+        rolling_hash = next_block.hash();
+        blocks.push(next_block.into());
+    }
 
-	// bench
-	benchmark.start();
-	for block in blocks {
-		let hash = block.hash().clone();
-		store.insert(block).unwrap();
-		store.canonize(&hash).unwrap();
-	}
-	benchmark.stop();
+    // bench
+    benchmark.start();
+    for block in blocks {
+        let hash = block.hash().clone();
+        store.insert(block).unwrap();
+        store.canonize(&hash).unwrap();
+    }
+    benchmark.stop();
 }
 
 pub fn reorg_short(benchmark: &mut Benchmark) {
-	// params
-	const BLOCKS: usize = 1000;
-	benchmark.samples(BLOCKS);
+    // params
+    const BLOCKS: usize = 1000;
+    benchmark.samples(BLOCKS);
 
-	// setup
-	let genesis: IndexedBlock = test_data::genesis().into();
-	let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
+    // setup
+    let genesis: IndexedBlock = test_data::genesis().into();
+    let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
 
-	let mut rolling_hash = genesis.hash().clone();
+    let mut rolling_hash = genesis.hash().clone();
 
-	let mut blocks = Vec::new();
+    let mut blocks = Vec::new();
 
-	for x in 0..BLOCKS {
-		let base = rolling_hash.clone();
+    for x in 0..BLOCKS {
+        let base = rolling_hash.clone();
 
-		let next_block = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(rolling_hash.clone()).nonce(x as u32 * 4).build()
-			.build();
-		rolling_hash = next_block.hash();
-		blocks.push(next_block);
+        let next_block = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32 * 4)
+            .build()
+            .build();
+        rolling_hash = next_block.hash();
+        blocks.push(next_block);
 
-		let next_block_side = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(base).nonce(x as u32 * 4 + 2).build()
-			.build();
-		let next_base = next_block_side.hash();
-		blocks.push(next_block_side);
+        let next_block_side = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(base)
+            .nonce(x as u32 * 4 + 2)
+            .build()
+            .build();
+        let next_base = next_block_side.hash();
+        blocks.push(next_block_side);
 
-		let next_block_side_continue = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(next_base).nonce(x as u32 * 4 + 3).build()
-			.build();
-		blocks.push(next_block_side_continue);
+        let next_block_side_continue = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(next_base)
+            .nonce(x as u32 * 4 + 3)
+            .build()
+            .build();
+        blocks.push(next_block_side_continue);
 
-		let next_block_continue = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(rolling_hash.clone()).nonce(x as u32 * 4 + 1).build()
-			.build();
-		rolling_hash = next_block_continue.hash();
-		blocks.push(next_block_continue);
-	}
+        let next_block_continue = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32 * 4 + 1)
+            .build()
+            .build();
+        rolling_hash = next_block_continue.hash();
+        blocks.push(next_block_continue);
+    }
 
-	let mut total: usize = 0;
-	let mut reorgs: usize = 0;
+    let mut total: usize = 0;
+    let mut reorgs: usize = 0;
 
-	// bench
-	benchmark.start();
-	for idx in 0..BLOCKS {
-		total += 1;
-		let block: IndexedBlock = blocks[idx].clone().into();
-		let hash = block.hash().clone();
+    // bench
+    benchmark.start();
+    for idx in 0..BLOCKS {
+        total += 1;
+        let block: IndexedBlock = blocks[idx].clone().into();
+        let hash = block.hash().clone();
 
-		match store.block_origin(&block.header).unwrap() {
-			BlockOrigin::KnownBlock => {
-				unreachable!();
-			},
-			BlockOrigin::CanonChain { .. } => {
-				store.insert(block).unwrap();
-				store.canonize(&hash).unwrap();
-			},
-			BlockOrigin::SideChain(_origin) => {
-				store.insert(block).unwrap();
-			},
-			BlockOrigin::SideChainBecomingCanonChain(origin) => {
-				reorgs += 1;
-				let fork = store.fork(origin).unwrap();
-				fork.store().insert(block).unwrap();
-				fork.store().canonize(&hash).unwrap();
-				store.switch_to_fork(fork).unwrap();
-			},
-		}
-	}
-	benchmark.stop();
+        match store.block_origin(&block.header).unwrap() {
+            BlockOrigin::KnownBlock => {
+                unreachable!();
+            }
+            BlockOrigin::CanonChain { .. } => {
+                store.insert(block).unwrap();
+                store.canonize(&hash).unwrap();
+            }
+            BlockOrigin::SideChain(_origin) => {
+                store.insert(block).unwrap();
+            }
+            BlockOrigin::SideChainBecomingCanonChain(origin) => {
+                reorgs += 1;
+                let fork = store.fork(origin).unwrap();
+                fork.store().insert(block).unwrap();
+                fork.store().canonize(&hash).unwrap();
+                store.switch_to_fork(fork).unwrap();
+            }
+        }
+    }
+    benchmark.stop();
 
-	// reorgs occur twice per iteration except last one where there only one, blocks are inserted with rate 4/iteration
-	// so reorgs = total/2 - 1
-	assert_eq!(1000, total);
-	assert_eq!(499, reorgs);
+    // reorgs occur twice per iteration except last one where there only one, blocks are inserted with rate 4/iteration
+    // so reorgs = total/2 - 1
+    assert_eq!(1000, total);
+    assert_eq!(499, reorgs);
 }
 
 // 1. write 12000 blocks
 // 2. write 100 blocks that has 100 transaction each spending outputs from first 1000 blocks
 pub fn write_heavy(benchmark: &mut Benchmark) {
-	// params
-	const BLOCKS_INITIAL: usize = 12000;
-	const BLOCKS: usize = 100;
-	const TRANSACTIONS: usize = 100;
+    // params
+    const BLOCKS_INITIAL: usize = 12000;
+    const BLOCKS: usize = 100;
+    const TRANSACTIONS: usize = 100;
 
-	benchmark.samples(BLOCKS);
+    benchmark.samples(BLOCKS);
 
-	// test setup
-	let genesis: IndexedBlock = test_data::genesis().into();
-	let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
+    // test setup
+    let genesis: IndexedBlock = test_data::genesis().into();
+    let store = BlockChainDatabase::init_test_chain(vec![genesis.clone()]);
 
-	let mut rolling_hash = genesis.hash().clone();
-	let mut blocks = Vec::new();
-	let mut hashes = Vec::new();
+    let mut rolling_hash = genesis.hash().clone();
+    let mut blocks = Vec::new();
+    let mut hashes = Vec::new();
 
-	for x in 0..BLOCKS_INITIAL {
-		let next_block = test_data::block_builder()
-			.transaction()
-				.coinbase()
-				.lock_time(x as u32)
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header().parent(rolling_hash.clone()).nonce(x as u32).build()
-			.build();
-		rolling_hash = next_block.hash();
-		blocks.push(next_block);
-		hashes.push(rolling_hash.clone());
-	}
+    for x in 0..BLOCKS_INITIAL {
+        let next_block = test_data::block_builder()
+            .transaction()
+            .coinbase()
+            .lock_time(x as u32)
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32)
+            .build()
+            .build();
+        rolling_hash = next_block.hash();
+        blocks.push(next_block);
+        hashes.push(rolling_hash.clone());
+    }
 
-	for b in 0..BLOCKS {
-		let mut builder = test_data::block_builder()
-			.transaction().coinbase().build();
+    for b in 0..BLOCKS {
+        let mut builder = test_data::block_builder().transaction().coinbase().build();
 
-		for t in 0..TRANSACTIONS {
-			builder = builder.transaction()
-				.input().hash(blocks[b*TRANSACTIONS+t].transactions()[0].hash()).build() // default index is 0 which is ok
-				.output().value(1000).build()
-				.build();
-		}
+        for t in 0..TRANSACTIONS {
+            builder = builder
+                .transaction()
+                .input()
+                .hash(blocks[b * TRANSACTIONS + t].transactions()[0].hash())
+                .build() // default index is 0 which is ok
+                .output()
+                .value(1000)
+                .build()
+                .build();
+        }
 
-		let next_block = builder.merkled_header().parent(rolling_hash).build().build();
+        let next_block = builder
+            .merkled_header()
+            .parent(rolling_hash)
+            .build()
+            .build();
 
-		rolling_hash = next_block.hash();
-		blocks.push(next_block);
-		hashes.push(rolling_hash.clone());
-	}
+        rolling_hash = next_block.hash();
+        blocks.push(next_block);
+        hashes.push(rolling_hash.clone());
+    }
 
-	for block in blocks[..BLOCKS_INITIAL].iter() {
-		let block: IndexedBlock = block.clone().into();
-		let hash = block.hash().clone();
-		store.insert(block).expect("cannot insert initial block");
-		store.canonize(&hash).unwrap();
-	}
+    for block in blocks[..BLOCKS_INITIAL].iter() {
+        let block: IndexedBlock = block.clone().into();
+        let hash = block.hash().clone();
+        store.insert(block).expect("cannot insert initial block");
+        store.canonize(&hash).unwrap();
+    }
 
-	// bench
-	benchmark.start();
-	for block in blocks[BLOCKS_INITIAL..].iter() {
-		let block: IndexedBlock = block.clone().into();
-		let hash = block.hash().clone();
-		store.insert(block).expect("cannot insert bench block");
-		store.canonize(&hash).unwrap();
-	}
-	benchmark.stop();
+    // bench
+    benchmark.start();
+    for block in blocks[BLOCKS_INITIAL..].iter() {
+        let block: IndexedBlock = block.clone().into();
+        let hash = block.hash().clone();
+        store.insert(block).expect("cannot insert bench block");
+        store.canonize(&hash).unwrap();
+    }
+    benchmark.stop();
 }

--- a/bencher/src/main.rs
+++ b/bencher/src/main.rs
@@ -1,79 +1,96 @@
-extern crate storage;
-extern crate db;
+extern crate byteorder;
 extern crate chain;
+extern crate db;
+extern crate network;
+extern crate primitives;
+extern crate storage;
 extern crate test_data;
 extern crate time;
 extern crate verification;
-extern crate network;
-extern crate byteorder;
-extern crate primitives;
+
+use std::io::Write;
+use std::str;
+
+use time::{Duration, PreciseTime};
 
 mod database;
 mod verifier;
 
-use time::{PreciseTime, Duration};
-use std::io::Write;
-use std::str;
-
 #[derive(Default)]
 pub struct Benchmark {
-	start: Option<PreciseTime>,
-	end: Option<PreciseTime>,
-	samples: Option<usize>,
+    start: Option<PreciseTime>,
+    end: Option<PreciseTime>,
+    samples: Option<usize>,
 }
 
 impl Benchmark {
-	pub fn start(&mut self) {
-		self.start = Some(PreciseTime::now());
-	}
+    pub fn start(&mut self) {
+        self.start = Some(PreciseTime::now());
+    }
 
-	pub fn stop(&mut self) {
-		self.end = Some(PreciseTime::now());
-	}
+    pub fn stop(&mut self) {
+        self.end = Some(PreciseTime::now());
+    }
 
-	pub fn evaluate(&self) -> Duration {
-		self.start.expect("benchmarch never ended").to(self.end.expect("benchmark never started"))
-	}
+    pub fn evaluate(&self) -> Duration {
+        self.start
+            .expect("benchmarch never ended")
+            .to(self.end.expect("benchmark never started"))
+    }
 
-	pub fn samples(&mut self, samples: usize) {
-		self.samples = Some(samples);
-	}
+    pub fn samples(&mut self, samples: usize) {
+        self.samples = Some(samples);
+    }
 }
 
 fn decimal_mark(s: String) -> String {
     let bytes: Vec<_> = s.bytes().rev().collect();
-    let chunks: Vec<_> = bytes.chunks(3).map(|chunk| str::from_utf8(chunk).unwrap()).collect();
+    let chunks: Vec<_> = bytes
+        .chunks(3)
+        .map(|chunk| str::from_utf8(chunk).unwrap())
+        .collect();
     let result: Vec<_> = chunks.join(",").bytes().rev().collect();
     String::from_utf8(result).unwrap()
 }
 
+fn run_benchmark<F>(name: &str, f: F)
+where
+    F: FnOnce(&mut Benchmark),
+{
+    print!("{}: ", name);
+    ::std::io::stdout().flush().unwrap();
 
-fn run_benchmark<F>(name: &str, f: F) where F: FnOnce(&mut Benchmark) {
-	print!("{}: ", name);
-	::std::io::stdout().flush().unwrap();
-
-	let mut benchmark = Benchmark::default();
-	f(&mut benchmark);
-	if let Some(samples) = benchmark.samples {
-		println!("{} ns/sample",
-			decimal_mark(format!("{}", benchmark.evaluate().num_nanoseconds().unwrap() / samples as i64)),
-		);
-	}
-	else {
-		println!("{} ns", decimal_mark(format!("{}", benchmark.evaluate().num_nanoseconds().unwrap())));
-	}
+    let mut benchmark = Benchmark::default();
+    f(&mut benchmark);
+    if let Some(samples) = benchmark.samples {
+        println!(
+            "{} ns/sample",
+            decimal_mark(format!(
+                "{}",
+                benchmark.evaluate().num_nanoseconds().unwrap() / samples as i64
+            )),
+        );
+    } else {
+        println!(
+            "{} ns",
+            decimal_mark(format!(
+                "{}",
+                benchmark.evaluate().num_nanoseconds().unwrap()
+            ))
+        );
+    }
 }
 
 macro_rules! benchmark {
     ($t:expr) => {
-    	run_benchmark(stringify!($t), $t);
+        run_benchmark(stringify!($t), $t);
     };
 }
 
 fn main() {
-	benchmark!(database::fetch);
-	benchmark!(database::write);
-	benchmark!(database::reorg_short);
-	benchmark!(database::write_heavy);
-	benchmark!(verifier::main);
+    benchmark!(database::fetch);
+    benchmark!(database::write);
+    benchmark!(database::reorg_short);
+    benchmark!(database::write_heavy);
+    benchmark!(verifier::main);
 }

--- a/bencher/src/verifier.rs
+++ b/bencher/src/verifier.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
-use db::BlockChainDatabase;
+
+use byteorder::{ByteOrder, LittleEndian};
+
 use chain::IndexedBlock;
-use verification::{BackwardsCompatibleChainVerifier as ChainVerifier, Verify, VerificationLevel};
-use network::{Network, ConsensusParams, ConsensusFork};
+use db::BlockChainDatabase;
+use network::{ConsensusFork, ConsensusParams, Network};
 use test_data;
-use byteorder::{LittleEndian, ByteOrder};
+use verification::{BackwardsCompatibleChainVerifier as ChainVerifier, VerificationLevel, Verify};
 
 use super::Benchmark;
 
@@ -12,96 +14,111 @@ use super::Benchmark;
 // 2. verify <BLOCKS> blocks that has <TRANSACTIONS> transaction each with <OUTPUTS> output each,
 //    spending outputs from last <BLOCKS*TRANSACTIONS*OUTPUTS> blocks
 pub fn main(benchmark: &mut Benchmark) {
-	// params
-	const BLOCKS_INITIAL: usize = 200200;
-	const BLOCKS: usize = 10;
-	const TRANSACTIONS: usize = 2000;
-	const OUTPUTS: usize = 10;
+    // params
+    const BLOCKS_INITIAL: usize = 200200;
+    const BLOCKS: usize = 10;
+    const TRANSACTIONS: usize = 2000;
+    const OUTPUTS: usize = 10;
 
-	benchmark.samples(BLOCKS);
+    benchmark.samples(BLOCKS);
 
-	assert!(BLOCKS_INITIAL - 100 > BLOCKS * OUTPUTS * TRANSACTIONS,
-		"There will be not enough initial blocks to continue this bench");
+    assert!(
+        BLOCKS_INITIAL - 100 > BLOCKS * OUTPUTS * TRANSACTIONS,
+        "There will be not enough initial blocks to continue this bench"
+    );
 
-	// test setup
-	let genesis = test_data::genesis();
+    // test setup
+    let genesis = test_data::genesis();
 
-	let mut rolling_hash = genesis.hash();
-	let mut blocks: Vec<IndexedBlock> = Vec::new();
+    let mut rolling_hash = genesis.hash();
+    let mut blocks: Vec<IndexedBlock> = Vec::new();
 
-	for x in 0..BLOCKS_INITIAL {
-		let mut coinbase_nonce = [0u8;8];
-		LittleEndian::write_u64(&mut coinbase_nonce[..], x as u64);
-		let next_block = test_data::block_builder()
-			.transaction()
-				.lock_time(x as u32)
-				.input()
-					.coinbase()
-					.signature_bytes(coinbase_nonce.to_vec().into())
-					.build()
-				.output().value(5000000000).build()
-				.build()
-			.merkled_header()
-				.parent(rolling_hash.clone())
-				.nonce(x as u32)
-				.build()
-			.build();
-		rolling_hash = next_block.hash();
-		blocks.push(next_block.into());
-	}
+    for x in 0..BLOCKS_INITIAL {
+        let mut coinbase_nonce = [0u8; 8];
+        LittleEndian::write_u64(&mut coinbase_nonce[..], x as u64);
+        let next_block = test_data::block_builder()
+            .transaction()
+            .lock_time(x as u32)
+            .input()
+            .coinbase()
+            .signature_bytes(coinbase_nonce.to_vec().into())
+            .build()
+            .output()
+            .value(5000000000)
+            .build()
+            .build()
+            .merkled_header()
+            .parent(rolling_hash.clone())
+            .nonce(x as u32)
+            .build()
+            .build();
+        rolling_hash = next_block.hash();
+        blocks.push(next_block.into());
+    }
 
-	let store = Arc::new(BlockChainDatabase::init_test_chain(vec![genesis.clone().into()]));
-	for block in blocks.iter() {
-		let hash = block.hash().clone();
-		store.insert(block.clone()).unwrap();
-		store.canonize(&hash).unwrap();
-	}
+    let store = Arc::new(BlockChainDatabase::init_test_chain(vec![genesis
+        .clone()
+        .into()]));
+    for block in blocks.iter() {
+        let hash = block.hash().clone();
+        store.insert(block.clone()).unwrap();
+        store.canonize(&hash).unwrap();
+    }
 
-	let mut verification_blocks: Vec<IndexedBlock> = Vec::new();
-	for b in 0..BLOCKS {
-		let mut coinbase_nonce = [0u8;8];
-		LittleEndian::write_u64(&mut coinbase_nonce[..], (b + BLOCKS_INITIAL) as u64);
-		let mut builder = test_data::block_builder()
-			.transaction()
-				.lock_time(b as u32)
-				.input().coinbase().signature_bytes(coinbase_nonce.to_vec().into()).build()
-				.output().value(5000000000).build()
-				.build();
+    let mut verification_blocks: Vec<IndexedBlock> = Vec::new();
+    for b in 0..BLOCKS {
+        let mut coinbase_nonce = [0u8; 8];
+        LittleEndian::write_u64(&mut coinbase_nonce[..], (b + BLOCKS_INITIAL) as u64);
+        let mut builder = test_data::block_builder()
+            .transaction()
+            .lock_time(b as u32)
+            .input()
+            .coinbase()
+            .signature_bytes(coinbase_nonce.to_vec().into())
+            .build()
+            .output()
+            .value(5000000000)
+            .build()
+            .build();
 
-		for t in 0..TRANSACTIONS {
-			let mut tx_builder = builder.transaction();
+        for t in 0..TRANSACTIONS {
+            let mut tx_builder = builder.transaction();
 
-			for o in 0..OUTPUTS {
-				let parent_hash = blocks[(b*TRANSACTIONS*OUTPUTS + t * OUTPUTS + o)].transactions[0].hash.clone();
+            for o in 0..OUTPUTS {
+                let parent_hash = blocks[(b * TRANSACTIONS * OUTPUTS + t * OUTPUTS + o)]
+                    .transactions[0]
+                    .hash
+                    .clone();
 
-				tx_builder = tx_builder
-					.input()
-						.hash(parent_hash)
-						.index(0)
-						.build()
-			}
+                tx_builder = tx_builder.input().hash(parent_hash).index(0).build()
+            }
 
-			builder = tx_builder.output().value(0).build().build()
-		}
+            builder = tx_builder.output().value(0).build().build()
+        }
 
-		verification_blocks.push(
-			builder
-				.merkled_header()
-					.parent(rolling_hash.clone())
-					.build()
-				.build()
-			.into());
-	}
+        verification_blocks.push(
+            builder
+                .merkled_header()
+                .parent(rolling_hash.clone())
+                .build()
+                .build()
+                .into(),
+        );
+    }
 
+    assert_eq!(store.best_block().hash, rolling_hash);
 
-	assert_eq!(store.best_block().hash, rolling_hash);
+    let chain_verifier = ChainVerifier::new(
+        store.clone(),
+        ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore),
+    );
 
-	let chain_verifier = ChainVerifier::new(store.clone(), ConsensusParams::new(Network::Unitest, ConsensusFork::BitcoinCore));
-
-	// bench
-	benchmark.start();
-	for block in verification_blocks.iter() {
-		chain_verifier.verify(VerificationLevel::Full, block).unwrap();
-	 }
-	benchmark.stop();
+    // bench
+    benchmark.start();
+    for block in verification_blocks.iter() {
+        chain_verifier
+            .verify(VerificationLevel::Full, block)
+            .unwrap();
+    }
+    benchmark.stop();
 }

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 rustc-hex = "2"
 heapsize = "0.4"
 rayon = "1.0"
+ethereum-types = "0.9"
 bitcrypto = { path = "../crypto" }
 primitives = { path = "../primitives" }
 serialization = { path = "../serialization" }

--- a/chain/src/constants.rs
+++ b/chain/src/constants.rs
@@ -11,7 +11,7 @@ pub const SEQUENCE_FINAL: u32 = 0xffffffff;
 // If CTxIn::nSequence encodes a relative lock-time and this flag
 // is set, the relative lock-time has units of 512 seconds,
 // otherwise it specifies blocks with a granularity of 1.
-pub const SEQUENCE_LOCKTIME_TYPE_FLAG: u32 = (1 << 22);
+pub const SEQUENCE_LOCKTIME_TYPE_FLAG: u32 = 1 << 22;
 
 // If CTxIn::nSequence encodes a relative lock-time, this mask is
 // applied to extract that lock-time from the sequence field.

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -1,11 +1,22 @@
-extern crate rustc_hex as hex;
+extern crate bitcrypto as crypto;
+extern crate ethereum_types;
 extern crate heapsize;
 extern crate primitives;
 extern crate rayon;
-extern crate bitcrypto as crypto;
+extern crate rustc_hex as hex;
 extern crate serialization as ser;
 #[macro_use]
 extern crate serialization_derive;
+
+pub use block::Block;
+pub use block_header::BlockHeader;
+pub use indexed_block::IndexedBlock;
+pub use indexed_header::IndexedBlockHeader;
+pub use indexed_transaction::IndexedTransaction;
+pub use merkle_root::{merkle_node_hash, merkle_root};
+pub use primitives::{bytes, compact, hash};
+pub use read_and_hash::{HashedData, ReadAndHash};
+pub use transaction::{OutPoint, Transaction, TransactionInput, TransactionOutput};
 
 pub mod constants;
 
@@ -19,17 +30,5 @@ mod read_and_hash;
 mod indexed_block;
 mod indexed_header;
 mod indexed_transaction;
-
-pub use primitives::{hash, bytes, bigint, compact};
-
-pub use block::Block;
-pub use block_header::BlockHeader;
-pub use merkle_root::{merkle_root, merkle_node_hash};
-pub use transaction::{Transaction, TransactionInput, TransactionOutput, OutPoint};
-
-pub use read_and_hash::{ReadAndHash, HashedData};
-pub use indexed_block::IndexedBlock;
-pub use indexed_header::IndexedBlockHeader;
-pub use indexed_transaction::IndexedTransaction;
 
 pub type ShortTransactionID = hash::H48;

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 
 [dependencies]
 lazy_static = "1.4.0"
+ethereum-types = "0.9"
 chain = { path = "../chain" }
 primitives = { path = "../primitives" }

--- a/network/src/lib.rs
+++ b/network/src/lib.rs
@@ -1,15 +1,15 @@
+extern crate chain;
+extern crate ethereum_types;
 #[macro_use]
 extern crate lazy_static;
-
-extern crate chain;
 extern crate primitives;
+
+pub use consensus::{BitcoinCashConsensusParams, ConsensusFork, ConsensusParams, TransactionOrdering};
+pub use deployments::Deployment;
+pub use network::{Magic, Network};
+pub use primitives::{compact, hash};
 
 mod consensus;
 mod deployments;
 mod network;
 
-pub use primitives::{hash, compact};
-
-pub use consensus::{ConsensusParams, ConsensusFork, BitcoinCashConsensusParams, TransactionOrdering};
-pub use deployments::Deployment;
-pub use network::{Magic, Network};

--- a/network/src/network.rs
+++ b/network/src/network.rs
@@ -1,11 +1,12 @@
 //! Bitcoin network
 //! https://www.anintegratedworld.com/unravelling-the-mysterious-block-chain-magic-number/
 
-use compact::Compact;
+use ethereum_types::U256;
+
+use ConsensusFork;
 use chain::IndexedBlock;
+use compact::Compact;
 use primitives::hash::H256;
-use primitives::bigint::U256;
-use {ConsensusFork};
 
 const MAGIC_MAINNET: u32 = 0xD9B4BEF9;
 const MAGIC_TESTNET: u32 = 0x0709110B;
@@ -101,11 +102,12 @@ impl Network {
 
 #[cfg(test)]
 mod tests {
+	use ConsensusFork;
 	use compact::Compact;
-	use {ConsensusFork};
+
 	use super::{
-		Network, MAGIC_MAINNET, MAGIC_TESTNET, MAGIC_REGTEST, MAGIC_UNITEST,
-		MAX_BITS_MAINNET, MAX_BITS_TESTNET, MAX_BITS_REGTEST,
+		MAGIC_MAINNET, MAGIC_REGTEST, MAGIC_TESTNET, MAGIC_UNITEST, MAX_BITS_MAINNET,
+		MAX_BITS_REGTEST, MAX_BITS_TESTNET, Network,
 	};
 
 	#[test]

--- a/pbtc/main.rs
+++ b/pbtc/main.rs
@@ -1,38 +1,40 @@
 //! Parity bitcoin client.
 
+extern crate app_dirs;
+extern crate chain;
 #[macro_use]
 extern crate clap;
+extern crate db;
+extern crate env_logger;
+extern crate import;
+extern crate keys;
+extern crate libc;
 #[macro_use]
 extern crate log;
-extern crate env_logger;
-extern crate app_dirs;
-extern crate libc;
-
-extern crate storage;
-extern crate db;
-extern crate chain;
-extern crate keys;
 extern crate logs;
-extern crate script;
 extern crate message;
 extern crate network;
 extern crate p2p;
-extern crate sync;
-extern crate import;
-extern crate rpc as ethcore_rpc;
 extern crate primitives;
+extern crate rpc as ethcore_rpc;
+extern crate script;
+extern crate storage;
+extern crate sync;
 extern crate verification;
-
-mod commands;
-mod config;
-mod seednodes;
-mod util;
-mod rpc;
-mod rpc_apis;
 
 use app_dirs::AppInfo;
 
-pub const APP_INFO: AppInfo = AppInfo { name: "pbtc", author: "Parity" };
+mod commands;
+mod config;
+mod rpc;
+mod rpc_apis;
+mod seednodes;
+mod util;
+
+pub const APP_INFO: AppInfo = AppInfo {
+	name: "pbtc",
+	author: "Parity",
+};
 pub const PROTOCOL_VERSION: u32 = 70_014;
 pub const PROTOCOL_MINIMUM: u32 = 70_001;
 pub const USER_AGENT: &'static str = "pbtc";

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 heapsize = "0.4"
 rustc-hex = "2"
 byteorder = "1.0"
-bigint = "1.0"
+ethereum-types = "0.9"

--- a/primitives/src/compact.rs
+++ b/primitives/src/compact.rs
@@ -1,6 +1,6 @@
 //! Compact representation of `U256`
 
-use bigint::{U256, Uint};
+use ethereum_types::U256;
 
 /// Compact representation of `U256`
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -54,9 +54,8 @@ impl Compact {
 		};
 
 		let is_negative = word != 0 && (self.0 & 0x00800000) != 0;
-		let is_overflow = (word != 0 && size > 34) ||
-				(word > 0xff && size > 33) ||
-				(word > 0xffff && size > 32);
+		let is_overflow =
+			(word != 0 && size > 34) || (word > 0xff && size > 33) || (word > 0xffff && size > 32);
 
 		if is_negative || is_overflow {
 			Err(result)
@@ -79,7 +78,7 @@ impl Compact {
 			size += 1;
 		}
 
-		assert!((compact & !0x007fffff) == 0);
+		assert_eq!(compact & !0x007fffff, 0);
 		assert!(size < 256);
 		Compact(compact | (size << 24) as u32)
 	}
@@ -101,7 +100,8 @@ impl Compact {
 
 #[cfg(test)]
 mod tests {
-	use bigint::{U256, Uint};
+	use ethereum_types::U256;
+
 	use super::Compact;
 
 	#[test]
@@ -120,7 +120,7 @@ mod tests {
 		let test1 = U256::from(1000u64);
 		assert_eq!(Compact::new(0x0203e800), Compact::from_u256(test1));
 
-		let test2 = U256::from(2).pow(U256::from(256-32)) - U256::from(1);
+		let test2 = U256::from(2).pow(U256::from(256 - 32)) - U256::from(1);
 		assert_eq!(Compact::new(0x1d00ffff), Compact::from_u256(test2));
 	}
 
@@ -143,7 +143,6 @@ mod tests {
 		}
 
 		assert!(compare_f64(Compact::new(0x1b0404cb).to_f64(), 16307.42094));
-	
 		// tests from original bitcoin client:
 		// https://github.com/bitcoin/bitcoin/blob/1e8f88e071019907785b260477bd359bef6f9a8f/src/test/blockchain_tests.cpp
 
@@ -151,6 +150,9 @@ mod tests {
 		assert!(compare_f64(Compact::new(0x1ef88f6f).to_f64(), 0.000016));
 		assert!(compare_f64(Compact::new(0x1df88f6f).to_f64(), 0.004023));
 		assert!(compare_f64(Compact::new(0x1cf88f6f).to_f64(), 1.029916));
-		assert!(compare_f64(Compact::new(0x12345678).to_f64(), 5913134931067755359633408.0));
+		assert!(compare_f64(
+			Compact::new(0x12345678).to_f64(),
+			5913134931067755359633408.0
+		));
 	}
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate byteorder;
+extern crate ethereum_types;
 #[macro_use]
 extern crate heapsize;
 extern crate rustc_hex as hex;
-pub extern crate bigint;
 
 pub mod bytes;
 pub mod compact;

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -9,6 +9,7 @@ lazy_static = "1.0"
 log = "0.4"
 rayon = "1.0"
 parking_lot = "0.4"
+ethereum-types = "0.9"
 primitives = { path = "../primitives" }
 chain = { path = "../chain"  }
 serialization = { path = "../serialization" }

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -51,23 +51,40 @@
 //! so instead we might want to call AcceptMemoryPoolTransaction on each tx
 //! that is inserted into assembled block
 
-extern crate time;
+extern crate bitcrypto as crypto;
+extern crate chain;
+#[cfg(test)]
+extern crate db;
+extern crate ethereum_types;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
-extern crate parking_lot;
-extern crate rayon;
-
-extern crate storage;
-extern crate chain;
 extern crate network;
+extern crate parking_lot;
 extern crate primitives;
-extern crate serialization as ser;
+extern crate rayon;
 extern crate script;
-extern crate bitcrypto as crypto;
-#[cfg(test)]
-extern crate db;
+extern crate serialization as ser;
+extern crate storage;
+extern crate time;
+
+pub use accept_block::BlockAcceptor;
+pub use accept_chain::ChainAcceptor;
+pub use accept_header::HeaderAcceptor;
+pub use accept_transaction::{MemoryPoolTransactionAcceptor, TransactionAcceptor};
+pub use canon::{CanonBlock, CanonHeader, CanonTransaction};
+pub use chain_verifier::BackwardsCompatibleChainVerifier;
+pub use deployments::Deployments;
+pub use error::{Error, TransactionError};
+pub use primitives::{compact, hash};
+pub use sigops::transaction_sigops;
+pub use timestamp::{median_timestamp, median_timestamp_inclusive};
+pub use verify_block::BlockVerifier;
+pub use verify_chain::ChainVerifier;
+pub use verify_header::HeaderVerifier;
+pub use verify_transaction::{MemoryPoolTransactionVerifier, TransactionVerifier};
+pub use work::{block_reward_satoshi, is_valid_proof_of_work, is_valid_proof_of_work_hash, work_required};
 
 pub mod constants;
 mod canon;
@@ -92,26 +109,6 @@ mod accept_transaction;
 
 // backwards compatibility
 mod chain_verifier;
-
-pub use primitives::{bigint, hash, compact};
-
-pub use canon::{CanonBlock, CanonHeader, CanonTransaction};
-pub use accept_block::BlockAcceptor;
-pub use accept_chain::ChainAcceptor;
-pub use accept_header::HeaderAcceptor;
-pub use accept_transaction::{TransactionAcceptor, MemoryPoolTransactionAcceptor};
-
-pub use verify_block::BlockVerifier;
-pub use verify_chain::ChainVerifier;
-pub use verify_header::HeaderVerifier;
-pub use verify_transaction::{TransactionVerifier, MemoryPoolTransactionVerifier};
-
-pub use chain_verifier::BackwardsCompatibleChainVerifier;
-pub use error::{Error, TransactionError};
-pub use sigops::transaction_sigops;
-pub use timestamp::{median_timestamp, median_timestamp_inclusive};
-pub use work::{work_required, is_valid_proof_of_work, is_valid_proof_of_work_hash, block_reward_satoshi};
-pub use deployments::Deployments;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 /// Blocks verification level.


### PR DESCRIPTION
- Replaced [deprecated bigint](https://crates.io/crates/bigint) with [ethereum_types](https://github.com/paritytech/parity-common/tree/master/ethereum-types)
- Rustfmt