### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Gitter [![Gitter https://gitter.im/paritytech/parity-bitcoin](https://badges.git
 Installing `pbtc` from source requires `rustc` and `cargo`.
 
 Minimal supported version is `rustc 1.23.0 (766bd11c8 2018-01-01)`
+Maximum supported version is `cargo 1.47.0 (f3c7e066a 2020-08-28)`
 
 #### Install rustc and cargo
 


### PR DESCRIPTION
The newest version of rust can not compile successfully, so add this constraint